### PR TITLE
[Feature/preferences/me/genres] 선호 장르 전체 저장 (replace) 구현

### DIFF
--- a/apps/preferences/serializers.py
+++ b/apps/preferences/serializers.py
@@ -47,5 +47,3 @@ class PreferenceGenresUpdateSerializer(serializers.Serializer):  # type: ignore[
                 code="invalid_genre_id",
             )
         return value
-
-

--- a/apps/preferences/serializers.py
+++ b/apps/preferences/serializers.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class PreferenceMeResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    genres = serializers.SerializerMethodField()
+    platforms = serializers.SerializerMethodField()
+    tags = serializers.SerializerMethodField()
+
+    def get_genres(self, obj: Any) -> list[dict[str, Any]]:
+        pref = getattr(obj, "preference", None)
+        if not pref:
+            return []
+        qs = pref.userpreferencegenre_set.select_related("genre").all()
+        return [{"id": ug.genre.id, "name": ug.genre.name, "slug": ug.genre.slug} for ug in qs]
+
+    def get_platforms(self, obj: Any) -> list[dict[str, Any]]:
+        pref = getattr(obj, "preference", None)
+        if not pref:
+            return []
+        qs = pref.userpreferenceplatform_set.select_related("platform").all()
+        return [{"id": up.platform.id, "name": up.platform.name, "slug": up.platform.slug} for up in qs]
+
+    def get_tags(self, obj: Any) -> list[dict[str, Any]]:
+        pref = getattr(obj, "preference", None)
+        if not pref:
+            return []
+        qs = pref.userpreferencetag_set.select_related("tag").all()
+        return [{"id": ut.tag.id, "name": ut.tag.name, "slug": ut.tag.slug} for ut in qs]
+
+
+class PreferenceGenresUpdateSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    genre_ids = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        allow_empty=True,
+    )
+
+    def validate_genre_ids(self, value: list[int]) -> list[int]:
+        from apps.games.models import Genre
+
+        existing = set(Genre.objects.filter(id__in=value).values_list("id", flat=True))
+        missing = set(value) - existing
+        if missing:
+            raise serializers.ValidationError(
+                detail=f"존재하지 않는 장르 id: {sorted(missing)}",
+                code="invalid_genre_id",
+            )
+        return value
+
+

--- a/apps/preferences/tests.py
+++ b/apps/preferences/tests.py
@@ -1,1 +1,134 @@
-# Create your tests here.
+from datetime import date
+from typing import Any, cast
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from apps.games.models import Genre, Platform, Tag
+from apps.preferences.models import UserPreference, UserPreferenceGenre, UserPreferencePlatform, UserPreferenceTag
+from apps.users.models import User
+
+
+class PreferenceMeAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/preferences/me/"
+
+    def test_preference_me_unauthorized(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_preference_me_empty_when_no_preference(self) -> None:
+        user = User.objects.create_user(
+            email="test@example.com",
+            nickname="tester",
+            birth_date=date(1990, 1, 1),
+            password="testpass123",
+        )
+        self.client.force_authenticate(user=user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data["genres"], [])
+        self.assertEqual(data["platforms"], [])
+        self.assertEqual(data["tags"], [])
+
+    def test_preference_me_returns_saved_preferences(self) -> None:
+        user = User.objects.create_user(
+            email="user2@example.com",
+            nickname="user2",
+            birth_date=date(1995, 5, 5),
+            password="testpass123",
+        )
+        pref = UserPreference.objects.create(user=user)
+
+        genre1 = Genre.objects.create(rawg_id=1001, name="RPG", slug="rpg")
+        genre2 = Genre.objects.create(rawg_id=1002, name="Action", slug="action")
+        platform1 = Platform.objects.create(rawg_id=2001, name="PC", slug="pc")
+        tag1 = Tag.objects.create(rawg_id=3001, name="Singleplayer", slug="singleplayer")
+
+        UserPreferenceGenre.objects.create(user_preference=pref, genre=genre1)
+        UserPreferenceGenre.objects.create(user_preference=pref, genre=genre2)
+        UserPreferencePlatform.objects.create(user_preference=pref, platform=platform1)
+        UserPreferenceTag.objects.create(user_preference=pref, tag=tag1)
+
+        self.client.force_authenticate(user=user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(len(data["genres"]), 2)
+        genre_ids = {g["id"] for g in data["genres"]}
+        self.assertEqual(genre_ids, {genre1.id, genre2.id})
+        for g in data["genres"]:
+            self.assertIn("slug", g)
+        self.assertEqual(len(data["platforms"]), 1)
+        self.assertEqual(data["platforms"][0]["id"], platform1.id)
+        self.assertEqual(data["platforms"][0]["name"], "PC")
+        self.assertEqual(data["platforms"][0]["slug"], "pc")
+        self.assertEqual(len(data["tags"]), 1)
+        self.assertEqual(data["tags"][0]["id"], tag1.id)
+        self.assertEqual(data["tags"][0]["name"], "Singleplayer")
+        self.assertEqual(data["tags"][0]["slug"], "singleplayer")
+
+
+class PreferenceMeGenresUpdateAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/preferences/me/genres/"
+
+    def test_put_genres_unauthorized(self) -> None:
+        response = self.client.put(self.url, {"genre_ids": [1]}, format="json")
+        self.assertEqual(response.status_code, 401)
+
+    def test_put_genres_invalid_id_returns_400(self) -> None:
+        user = User.objects.create_user(
+            email="u@ex.com",
+            nickname="u",
+            birth_date=date(1990, 1, 1),
+            password="pw",
+        )
+        self.client.force_authenticate(user=user)
+        response = self.client.put(self.url, {"genre_ids": [99999]}, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_put_genres_replace_and_return_200(self) -> None:
+        user = User.objects.create_user(
+            email="u2@ex.com",
+            nickname="u2",
+            birth_date=date(1995, 1, 1),
+            password="pw",
+        )
+        g1 = Genre.objects.create(rawg_id=101, name="RPG", slug="rpg")
+        g2 = Genre.objects.create(rawg_id=102, name="Action", slug="action")
+        self.client.force_authenticate(user=user)
+
+        response = self.client.put(self.url, {"genre_ids": [g1.id, g2.id]}, format="json")
+        self.assertEqual(response.status_code, 200)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(len(data["genres"]), 2)
+        self.assertEqual({g["id"] for g in data["genres"]}, {g1.id, g2.id})
+
+        response2 = self.client.put(self.url, {"genre_ids": [g1.id]}, format="json")
+        self.assertEqual(response2.status_code, 200)
+        data2 = cast(dict[str, Any], response2.data)
+        self.assertEqual(len(data2["genres"]), 1)
+        self.assertEqual(data2["genres"][0]["id"], g1.id)
+
+    def test_put_genres_empty_list_clears(self) -> None:
+        user = User.objects.create_user(
+            email="u3@ex.com",
+            nickname="u3",
+            birth_date=date(1992, 1, 1),
+            password="pw",
+        )
+        pref = UserPreference.objects.create(user=user)
+        g = Genre.objects.create(rawg_id=103, name="Indie", slug="indie")
+        UserPreferenceGenre.objects.create(user_preference=pref, genre=g)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.put(self.url, {"genre_ids": []}, format="json")

--- a/apps/preferences/tests.py
+++ b/apps/preferences/tests.py
@@ -131,4 +131,7 @@ class PreferenceMeGenresUpdateAPITestCase(TestCase):
         UserPreferenceGenre.objects.create(user_preference=pref, genre=g)
         self.client.force_authenticate(user=user)
 
-        response = self.client.put(self.url, {"genre_ids": []}, format="json")
+        res = self.client.put(self.url, {"genre_ids": []}, format="json")
+        self.assertEqual(res.status_code, 200)
+        data = cast(dict[str, Any], res.data)
+        self.assertEqual(data["genres"], [])

--- a/apps/preferences/urls.py
+++ b/apps/preferences/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from apps.preferences.views import PreferenceMeGenresUpdateView, PreferenceMeRetrieveView
+
+urlpatterns = [
+    path("me/", PreferenceMeRetrieveView.as_view(), name="preference-me-retrieve"),
+    path("me/genres/", PreferenceMeGenresUpdateView.as_view(), name="preference-me-genres-update"),
+]

--- a/apps/preferences/views.py
+++ b/apps/preferences/views.py
@@ -1,1 +1,32 @@
-# Create your views here.
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.preferences.models import UserPreference, UserPreferenceGenre
+from apps.preferences.serializers import PreferenceGenresUpdateSerializer, PreferenceMeResponseSerializer
+
+
+class PreferenceMeRetrieveView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        serializer = PreferenceMeResponseSerializer(request.user)
+        return Response(serializer.data)
+
+
+class PreferenceMeGenresUpdateView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def put(self, request: Request) -> Response:
+        req_serializer = PreferenceGenresUpdateSerializer(data=request.data)
+        req_serializer.is_valid(raise_exception=True)
+        genre_ids: list[int] = req_serializer.validated_data["genre_ids"]
+
+        pref, _ = UserPreference.objects.get_or_create(user=request.user)
+        UserPreferenceGenre.objects.filter(user_preference=pref).delete()
+        for gid in genre_ids:
+            UserPreferenceGenre.objects.create(user_preference=pref, genre_id=gid)
+
+        response_serializer = PreferenceMeResponseSerializer(request.user)
+        return Response(response_serializer.data)

--- a/config/urls.py
+++ b/config/urls.py
@@ -9,19 +9,20 @@ Function views
     2. Add a URL to urlpatterns:  path('', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  path('blog/', Home.as_view(), name='home')
 Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 urlpatterns = [
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path("api/schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
     path("api/schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
+    path("api/v1/preferences/", include("apps.preferences.urls")),
     path("admin/", admin.site.urls),
 ]


### PR DESCRIPTION
## ✅ PR 요약
- PUT `/api/v1/preferences/me/genres` API 구현 (선호 장르 전체 replace)

## 상세 내용
- [x] 인증 사용자 대상 선호 장르 전체 저장 API (PUT `me/genres/`)
- [x] 요청 body `genre_ids` 배열로 기존 선호 장르 전부 교체
- [x] 존재하지 않는 장르 id 시 400 검증, 응답은 GET me와 동일 형식

## 테스트
- [x] 로컬에서 확인했습니다.
- [ ] 빌드/린트가 통과합니다. (가능한 경우)

## 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)