### PR TITLE
자 동 배 포

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build, tag, and push Docker image
+      - name: Build, tag, and push Docker images
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: gechu-backend
@@ -41,6 +41,11 @@ jobs:
             -t $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG \
             -f docker/Dockerfile.prod .
           docker push $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+          docker build \
+            -t $ECR_REGISTRY/gechu-nginx:$IMAGE_TAG \
+            -f resources/nginx/prod.Dockerfile .
+          docker push $ECR_REGISTRY/gechu-nginx:$IMAGE_TAG
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
       - closed
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -15,15 +16,43 @@ jobs:
     if: |
       github.event.pull_request.merged == true &&
       vars.ENABLE_EC2_DEPLOY == 'true'
-
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push Docker image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: gechu-backend
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build \
+            -t $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG \
+            -f docker/Dockerfile.prod .
+          docker push $ECR_REGISTRY/$REPOSITORY:$IMAGE_TAG
+
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: gechu-backend
+          IMAGE_TAG: ${{ github.sha }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
+          envs: ECR_REGISTRY,REPOSITORY,IMAGE_TAG
           script: |
             set -e
             cd ~/gechu-backend
@@ -31,7 +60,16 @@ jobs:
             git checkout dev
             git pull origin dev
             cd docker
-            docker compose -f docker-compose.prod.yml up -d --build
-            docker compose -f docker-compose.prod.yml exec -T django python manage.py migrate
+
             docker image prune -af || true
+
+            IMAGE_TAG=$IMAGE_TAG docker compose -f docker-compose.prod.yml pull
+            IMAGE_TAG=$IMAGE_TAG docker compose -f docker-compose.prod.yml up -d --wait
+
+            # Django 마이그레이션
+            docker compose -f docker-compose.prod.yml exec -T django \
+              python manage.py migrate --noinput
+
+            docker system prune -f --volumes --filter "until=24h" || true
+
             echo "[Success] Deployment successful"

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -86,6 +86,7 @@ services:
     restart: unless-stopped
 
   nginx:
+    image: ${ECR_REGISTRY}/gechu-nginx:${IMAGE_TAG}
     build:
       context: ..
       dockerfile: resources/nginx/prod.Dockerfile

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,0 +1,106 @@
+services:
+  django:
+    image: ${ECR_REGISTRY}/${REPOSITORY}:${IMAGE_TAG}
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      args:
+        ENV: prod
+    container_name: django-prod
+    command: gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3
+    volumes:
+      - static_volume:/app/staticfiles
+    expose:
+      - "8000"
+    env_file:
+      - ../envs/.prod.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  celery-worker:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      args:
+        ENV: prod
+    container_name: celery-worker-prod
+    command: celery -A config worker -l info
+    env_file:
+      - ../envs/.prod.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  celery-beat:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      args:
+        ENV: prod
+    container_name: celery-beat-prod
+    command: celery -A config beat -l info
+    env_file:
+      - ../envs/.prod.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:17-alpine
+    container_name: postgres-prod
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - postgres_prod_data:/var/lib/postgresql/data
+    expose:
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: redis-prod
+    expose:
+      - "6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  nginx:
+    build:
+      context: ..
+      dockerfile: resources/nginx/prod.Dockerfile
+    container_name: nginx-prod
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - static_volume:/app/staticfiles:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro        # certbot SSL 인증서
+      - /var/www/certbot:/var/www/certbot:ro         # certbot 인증 챌린지
+    depends_on:
+      - django
+    restart: unless-stopped
+
+volumes:
+  postgres_prod_data:
+  static_volume:


### PR DESCRIPTION
## 요약
- dev 머지 시 GitHub Actions로 ECR에 이미지 빌드·푸시 후, EC2에서 pull하여 배포되도록 설정 반영

- 'github/workflows/deploy.yml`: OIDC → ECR 로그인 → 이미지 빌드/푸시 → EC2 SSH 배포 (pull, up, migrate)
- `docker/docker-compose.prod.yml`: django 서비스에 ECR 이미지 사용 (`image: ${ECR_REGISTRY}/${REPOSITORY}:${IMAGE_TAG}`) 추가

AWS OIDC 역할, ECR 저장소(gechu-backend), EC2 IAM(ECR pull), GitHub 시크릿/변수 설정 완료된 상태