### PR TITLE
[Feature/preferences/me/tags] 선호 태그 전체 저장 API (PUT me/tags)

### DIFF
--- a/apps/preferences/serializers.py
+++ b/apps/preferences/serializers.py
@@ -66,3 +66,22 @@ class PreferencePlatformsUpdateSerializer(serializers.Serializer):  # type: igno
                 code="invalid_platform_id",
             )
         return value
+
+
+class PreferenceTagsUpdateSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    tag_ids = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        allow_empty=True,
+    )
+
+    def validate_tag_ids(self, value: list[int]) -> list[int]:
+        from apps.games.models import Tag
+
+        existing = set(Tag.objects.filter(id__in=value).values_list("id", flat=True))
+        missing = set(value) - existing
+        if missing:
+            raise serializers.ValidationError(
+                detail=f"존재하지 않는 태그 id: {sorted(missing)}",
+                code="invalid_tag_id",
+            )
+        return value

--- a/apps/preferences/tests.py
+++ b/apps/preferences/tests.py
@@ -199,3 +199,66 @@ class PreferenceMePlatformsUpdateAPITestCase(TestCase):
         self.assertEqual(res.status_code, 200)
         data = cast(dict[str, Any], res.data)
         self.assertEqual(data["platforms"], [])
+
+
+class PreferenceMeTagsUpdateAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/preferences/me/tags/"
+
+    def test_put_tags_unauthorized(self) -> None:
+        response = self.client.put(self.url, {"tag_ids": [1]}, format="json")
+        self.assertEqual(response.status_code, 401)
+
+    def test_put_tags_invalid_id_returns_400(self) -> None:
+        user = User.objects.create_user(
+            email="u@ex.com",
+            nickname="u",
+            birth_date=date(1990, 1, 1),
+            password="pw",
+        )
+        self.client.force_authenticate(user=user)
+        response = self.client.put(self.url, {"tag_ids": [99999]}, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_put_tags_replace_and_return_200(self) -> None:
+        user = User.objects.create_user(
+            email="u2@ex.com",
+            nickname="u2",
+            birth_date=date(1995, 1, 1),
+            password="pw",
+        )
+        t1 = Tag.objects.create(rawg_id=301, name="RPG", slug="rpg")
+        t2 = Tag.objects.create(rawg_id=302, name="Multiplayer", slug="multiplayer")
+        self.client.force_authenticate(user=user)
+
+        response = self.client.put(self.url, {"tag_ids": [t1.id, t2.id]}, format="json")
+        self.assertEqual(response.status_code, 200)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(len(data["tags"]), 2)
+        self.assertEqual({t["id"] for t in data["tags"]}, {t1.id, t2.id})
+
+        response2 = self.client.put(self.url, {"tag_ids": [t1.id]}, format="json")
+        self.assertEqual(response2.status_code, 200)
+        data2 = cast(dict[str, Any], response2.data)
+        self.assertEqual(len(data2["tags"]), 1)
+        self.assertEqual(data2["tags"][0]["id"], t1.id)
+
+    def test_put_tags_empty_list_clears(self) -> None:
+        user = User.objects.create_user(
+            email="u3@ex.com",
+            nickname="u3",
+            birth_date=date(1992, 1, 1),
+            password="pw",
+        )
+        pref = UserPreference.objects.create(user=user)
+        t = Tag.objects.create(rawg_id=303, name="Singleplayer", slug="singleplayer")
+        UserPreferenceTag.objects.create(user_preference=pref, tag=t)
+        self.client.force_authenticate(user=user)
+
+        res = self.client.put(self.url, {"tag_ids": []}, format="json")
+        self.assertEqual(res.status_code, 200)
+        data = cast(dict[str, Any], res.data)
+        self.assertEqual(data["tags"], [])

--- a/apps/preferences/urls.py
+++ b/apps/preferences/urls.py
@@ -4,10 +4,12 @@ from apps.preferences.views import (
     PreferenceMeGenresUpdateView,
     PreferenceMePlatformsUpdateView,
     PreferenceMeRetrieveView,
+    PreferenceMeTagsUpdateView,
 )
 
 urlpatterns = [
     path("me/", PreferenceMeRetrieveView.as_view(), name="preference-me-retrieve"),
     path("me/genres/", PreferenceMeGenresUpdateView.as_view(), name="preference-me-genres-update"),
     path("me/platforms/", PreferenceMePlatformsUpdateView.as_view(), name="preference-me-platforms-update"),
+    path("me/tags/", PreferenceMeTagsUpdateView.as_view(), name="preference-me-tags-update"),
 ]

--- a/apps/preferences/views.py
+++ b/apps/preferences/views.py
@@ -72,8 +72,13 @@ class PreferenceMeTagsUpdateView(APIView):
         pref, _ = UserPreference.objects.get_or_create(user=request.user)
         with transaction.atomic():
             UserPreferenceTag.objects.filter(user_preference=pref).delete()
+<<<<<<< HEAD
             tags_to_create = [UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids]
             UserPreferenceTag.objects.bulk_create(tags_to_create)
+=======
+            for tid in tag_ids:
+                UserPreferenceTag.objects.create(user_preference=pref, tag_id=tid)
+>>>>>>> 4a1f153 (fix: transaction.atomic 적용)
 
         response_serializer = PreferenceMeResponseSerializer(request.user)
         return Response(response_serializer.data)

--- a/apps/preferences/views.py
+++ b/apps/preferences/views.py
@@ -1,14 +1,16 @@
+from django.db import transaction
 from drf_spectacular.utils import extend_schema
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.preferences.models import UserPreference, UserPreferenceGenre, UserPreferencePlatform
+from apps.preferences.models import UserPreference, UserPreferenceGenre, UserPreferencePlatform, UserPreferenceTag
 from apps.preferences.serializers import (
     PreferenceGenresUpdateSerializer,
     PreferenceMeResponseSerializer,
     PreferencePlatformsUpdateSerializer,
+    PreferenceTagsUpdateSerializer,
 )
 
 
@@ -47,9 +49,31 @@ class PreferenceMePlatformsUpdateView(APIView):
         platform_ids: list[int] = req_serializer.validated_data["platform_ids"]
 
         pref, _ = UserPreference.objects.get_or_create(user=request.user)
-        UserPreferencePlatform.objects.filter(user_preference=pref).delete()
-        for pid in platform_ids:
-            UserPreferencePlatform.objects.create(user_preference=pref, platform_id=pid)
+        with transaction.atomic():
+            UserPreferencePlatform.objects.filter(user_preference=pref).delete()
+            platforms_to_create = [
+                UserPreferencePlatform(user_preference=pref, platform_id=pid) for pid in platform_ids
+            ]
+            UserPreferencePlatform.objects.bulk_create(platforms_to_create)
+
+        response_serializer = PreferenceMeResponseSerializer(request.user)
+        return Response(response_serializer.data)
+
+
+@extend_schema(tags=["Preferences"])
+class PreferenceMeTagsUpdateView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def put(self, request: Request) -> Response:
+        req_serializer = PreferenceTagsUpdateSerializer(data=request.data)
+        req_serializer.is_valid(raise_exception=True)
+        tag_ids: list[int] = req_serializer.validated_data["tag_ids"]
+
+        pref, _ = UserPreference.objects.get_or_create(user=request.user)
+        with transaction.atomic():
+            UserPreferenceTag.objects.filter(user_preference=pref).delete()
+            tags_to_create = [UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids]
+            UserPreferenceTag.objects.bulk_create(tags_to_create)
 
         response_serializer = PreferenceMeResponseSerializer(request.user)
         return Response(response_serializer.data)

--- a/apps/preferences/views.py
+++ b/apps/preferences/views.py
@@ -72,20 +72,10 @@ class PreferenceMeTagsUpdateView(APIView):
         pref, _ = UserPreference.objects.get_or_create(user=request.user)
         with transaction.atomic():
             UserPreferenceTag.objects.filter(user_preference=pref).delete()
-<<<<<<< HEAD
-<<<<<<< HEAD
-            tags_to_create = [UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids]
-            UserPreferenceTag.objects.bulk_create(tags_to_create)
-=======
-            for tid in tag_ids:
-                UserPreferenceTag.objects.create(user_preference=pref, tag_id=tid)
->>>>>>> 4a1f153 (fix: transaction.atomic 적용)
-=======
             tags_to_create = [
                 UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids
             ]
             UserPreferenceTag.objects.bulk_create(tags_to_create)
->>>>>>> ba40d71 (bulk_create 적용)
 
         response_serializer = PreferenceMeResponseSerializer(request.user)
         return Response(response_serializer.data)

--- a/apps/preferences/views.py
+++ b/apps/preferences/views.py
@@ -73,12 +73,19 @@ class PreferenceMeTagsUpdateView(APIView):
         with transaction.atomic():
             UserPreferenceTag.objects.filter(user_preference=pref).delete()
 <<<<<<< HEAD
+<<<<<<< HEAD
             tags_to_create = [UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids]
             UserPreferenceTag.objects.bulk_create(tags_to_create)
 =======
             for tid in tag_ids:
                 UserPreferenceTag.objects.create(user_preference=pref, tag_id=tid)
 >>>>>>> 4a1f153 (fix: transaction.atomic 적용)
+=======
+            tags_to_create = [
+                UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids
+            ]
+            UserPreferenceTag.objects.bulk_create(tags_to_create)
+>>>>>>> ba40d71 (bulk_create 적용)
 
         response_serializer = PreferenceMeResponseSerializer(request.user)
         return Response(response_serializer.data)

--- a/apps/preferences/views.py
+++ b/apps/preferences/views.py
@@ -72,9 +72,7 @@ class PreferenceMeTagsUpdateView(APIView):
         pref, _ = UserPreference.objects.get_or_create(user=request.user)
         with transaction.atomic():
             UserPreferenceTag.objects.filter(user_preference=pref).delete()
-            tags_to_create = [
-                UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids
-            ]
+            tags_to_create = [UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids]
             UserPreferenceTag.objects.bulk_create(tags_to_create)
 
         response_serializer = PreferenceMeResponseSerializer(request.user)


### PR DESCRIPTION
## ✅ PR 요약
- PUT /api/v1/preferences/me/tags/ API 추가 — 선호 태그 전체 저장(replace)

## 📄 상세 내용
- [x] PreferenceTagsUpdateSerializer 추가 (tag_ids 검증)
- [x] PreferenceMeTagsUpdateView 추가 (replace 로직)
- [x] 테스트 4개 추가 (unauthorized, invalid_id, replace, empty_list)

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] 빌드/린트가 통과합니다. (가능한 경우)

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
