### PR TITLE
[Feature/preferences/games/game_id] 게임 취향 상태 설정 api 구현

### DIFF
--- a/apps/preferences/serializers.py
+++ b/apps/preferences/serializers.py
@@ -2,6 +2,9 @@ from typing import Any
 
 from rest_framework import serializers
 
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+
 
 class PreferenceMeResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
     genres = serializers.SerializerMethodField()
@@ -92,7 +95,12 @@ REACTION_CHOICES = ("like", "dislike", "neutral")
 
 class PreferenceGameReactionUpdateSerializer(serializers.Serializer):  # type: ignore[type-arg]
     is_saved = serializers.BooleanField(required=False)
-    reaction = serializers.ChoiceField(choices=REACTION_CHOICES, required=False)
+    reaction = serializers.CharField(required=False)
+
+    def validate_reaction(self, value: str | None) -> str | None:
+        if value is not None and value not in REACTION_CHOICES:
+            raise CustomAPIException(ErrorMessages.INVALID_REACTION)
+        return value
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         if not attrs:

--- a/apps/preferences/serializers.py
+++ b/apps/preferences/serializers.py
@@ -85,3 +85,19 @@ class PreferenceTagsUpdateSerializer(serializers.Serializer):  # type: ignore[ty
                 code="invalid_tag_id",
             )
         return value
+
+
+REACTION_CHOICES = ("like", "dislike", "neutral")
+
+
+class PreferenceGameReactionUpdateSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    is_saved = serializers.BooleanField(required=False)
+    reaction = serializers.ChoiceField(choices=REACTION_CHOICES, required=False)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if not attrs:
+            raise serializers.ValidationError(
+                detail="is_saved 또는 reaction 중 하나 이상 필요합니다.",
+                code="validation_error",
+            )
+        return attrs

--- a/apps/preferences/tests.py
+++ b/apps/preferences/tests.py
@@ -321,6 +321,28 @@ class PreferenceGameReactionUpdateAPITestCase(TestCase):
         response = self.client.put(self._url(game.id), {}, format="json")
         self.assertEqual(response.status_code, 400)
 
+    def test_put_game_reaction_invalid_reaction_returns_400(self) -> None:
+        user = User.objects.create_user(
+            email="u@ex.com",
+            nickname="u",
+            birth_date=date(1990, 1, 1),
+            password="pw",
+        )
+        game = _create_game()
+        self.client.force_authenticate(user=user)
+        response = self.client.put(
+            self._url(game.id),
+            {"reaction": "invalid_value"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "INVALID_REACTION")
+        self.assertEqual(
+            data.get("message"),
+            "reaction은 like, dislike, neutral 중 하나여야 합니다.",
+        )
+
     def test_put_game_reaction_is_saved(self) -> None:
         user = User.objects.create_user(
             email="u@ex.com",
@@ -334,6 +356,7 @@ class PreferenceGameReactionUpdateAPITestCase(TestCase):
         response = self.client.put(self._url(game.id), {"is_saved": True}, format="json")
         self.assertEqual(response.status_code, 200)
         data = cast(dict[str, Any], response.data)
+        self.assertEqual(data["game_id"], game.id)
         self.assertTrue(data["is_saved"])
         self.assertEqual(data["reaction"], "neutral")
         self.assertIn("updated_at", data)

--- a/apps/preferences/tests.py
+++ b/apps/preferences/tests.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 from datetime import date
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from django.test import TestCase
+
+if TYPE_CHECKING:
+    from apps.games.models import Game
 from rest_framework.test import APIClient
 
 from apps.games.models import Genre, Platform, Tag
@@ -262,3 +267,123 @@ class PreferenceMeTagsUpdateAPITestCase(TestCase):
         self.assertEqual(res.status_code, 200)
         data = cast(dict[str, Any], res.data)
         self.assertEqual(data["tags"], [])
+
+
+def _create_game(**kwargs: Any) -> Game:
+    from apps.games.models import Game
+
+    defaults = {
+        "rawg_id": 5001,
+        "slug": "test-game",
+        "name": "Test Game",
+        "thumbnail_img_url": "https://example.com/thumb.jpg",
+        "website": "https://example.com",
+        "is_visible": True,
+    }
+    defaults.update(kwargs)
+    return Game.objects.create(**defaults)
+
+
+class PreferenceGameReactionUpdateAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    def _url(self, game_id: int) -> str:
+        return f"/api/v1/preferences/games/{game_id}/"
+
+    def test_put_game_reaction_unauthorized(self) -> None:
+        game = _create_game()
+        response = self.client.put(self._url(game.id), {"is_saved": True}, format="json")
+        self.assertEqual(response.status_code, 401)
+
+    def test_put_game_reaction_game_not_found(self) -> None:
+        user = User.objects.create_user(
+            email="u@ex.com",
+            nickname="u",
+            birth_date=date(1990, 1, 1),
+            password="pw",
+        )
+        self.client.force_authenticate(user=user)
+        response = self.client.put(self._url(99999), {"is_saved": True}, format="json")
+        self.assertEqual(response.status_code, 404)
+
+    def test_put_game_reaction_empty_body_returns_400(self) -> None:
+        user = User.objects.create_user(
+            email="u@ex.com",
+            nickname="u",
+            birth_date=date(1990, 1, 1),
+            password="pw",
+        )
+        game = _create_game()
+        self.client.force_authenticate(user=user)
+        response = self.client.put(self._url(game.id), {}, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_put_game_reaction_is_saved(self) -> None:
+        user = User.objects.create_user(
+            email="u@ex.com",
+            nickname="u",
+            birth_date=date(1990, 1, 1),
+            password="pw",
+        )
+        game = _create_game()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.put(self._url(game.id), {"is_saved": True}, format="json")
+        self.assertEqual(response.status_code, 200)
+        data = cast(dict[str, Any], response.data)
+        self.assertTrue(data["is_saved"])
+        self.assertEqual(data["reaction"], "neutral")
+        self.assertIn("updated_at", data)
+
+        response2 = self.client.put(self._url(game.id), {"is_saved": False}, format="json")
+        self.assertEqual(response2.status_code, 200)
+        data2 = cast(dict[str, Any], response2.data)
+        self.assertFalse(data2["is_saved"])
+
+    def test_put_game_reaction_like_dislike(self) -> None:
+        user = User.objects.create_user(
+            email="u2@ex.com",
+            nickname="u2",
+            birth_date=date(1995, 1, 1),
+            password="pw",
+        )
+        game = _create_game()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.put(self._url(game.id), {"reaction": "like"}, format="json")
+        self.assertEqual(response.status_code, 200)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data["reaction"], "like")
+
+        response2 = self.client.put(self._url(game.id), {"reaction": "dislike"}, format="json")
+        self.assertEqual(response2.status_code, 200)
+        data2 = cast(dict[str, Any], response2.data)
+        self.assertEqual(data2["reaction"], "dislike")
+
+        response3 = self.client.put(self._url(game.id), {"reaction": "neutral"}, format="json")
+        self.assertEqual(response3.status_code, 200)
+        data3 = cast(dict[str, Any], response3.data)
+        self.assertEqual(data3["reaction"], "neutral")
+
+    def test_put_game_reaction_both_is_saved_and_reaction(self) -> None:
+        user = User.objects.create_user(
+            email="u3@ex.com",
+            nickname="u3",
+            birth_date=date(1992, 1, 1),
+            password="pw",
+        )
+        game = _create_game()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.put(
+            self._url(game.id),
+            {"is_saved": True, "reaction": "like"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = cast(dict[str, Any], response.data)
+        self.assertTrue(data["is_saved"])
+        self.assertEqual(data["reaction"], "like")

--- a/apps/preferences/urls.py
+++ b/apps/preferences/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from apps.preferences.views import (
+    PreferenceGameReactionUpdateView,
     PreferenceMeGenresUpdateView,
     PreferenceMePlatformsUpdateView,
     PreferenceMeRetrieveView,
@@ -12,4 +13,5 @@ urlpatterns = [
     path("me/genres/", PreferenceMeGenresUpdateView.as_view(), name="preference-me-genres-update"),
     path("me/platforms/", PreferenceMePlatformsUpdateView.as_view(), name="preference-me-platforms-update"),
     path("me/tags/", PreferenceMeTagsUpdateView.as_view(), name="preference-me-tags-update"),
+    path("games/<int:game_id>/", PreferenceGameReactionUpdateView.as_view(), name="preference-game-reaction-update"),
 ]

--- a/apps/preferences/views.py
+++ b/apps/preferences/views.py
@@ -1,17 +1,32 @@
+from typing import cast
+
 from django.db import transaction
+from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.preferences.models import UserPreference, UserPreferenceGenre, UserPreferencePlatform, UserPreferenceTag
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.games.models import Game
+from apps.interactions.models import InteractionLog
+from apps.preferences.models import (
+    UserGameAffinity,
+    UserPreference,
+    UserPreferenceGenre,
+    UserPreferencePlatform,
+    UserPreferenceTag,
+)
 from apps.preferences.serializers import (
+    PreferenceGameReactionUpdateSerializer,
     PreferenceGenresUpdateSerializer,
     PreferenceMeResponseSerializer,
     PreferencePlatformsUpdateSerializer,
     PreferenceTagsUpdateSerializer,
 )
+from apps.users.models import User
 
 
 class PreferenceMeRetrieveView(APIView):
@@ -72,15 +87,94 @@ class PreferenceMeTagsUpdateView(APIView):
         pref, _ = UserPreference.objects.get_or_create(user=request.user)
         with transaction.atomic():
             UserPreferenceTag.objects.filter(user_preference=pref).delete()
-<<<<<<< HEAD
-            tags_to_create = [
-                UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids
-            ]
+            tags_to_create = [UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids]
             UserPreferenceTag.objects.bulk_create(tags_to_create)
-=======
-            for tid in tag_ids:
-                UserPreferenceTag.objects.create(user_preference=pref, tag_id=tid)
->>>>>>> 4a1f153 (fix: transaction.atomic 적용)
 
         response_serializer = PreferenceMeResponseSerializer(request.user)
         return Response(response_serializer.data)
+
+
+@extend_schema(tags=["Preferences"])
+class PreferenceGameReactionUpdateView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def put(self, request: Request, game_id: int) -> Response:
+        req_serializer = PreferenceGameReactionUpdateSerializer(data=request.data, partial=True)
+        req_serializer.is_valid(raise_exception=True)
+        data = req_serializer.validated_data
+
+        if not Game.objects.filter(pk=game_id, is_visible=True).exists():
+            raise CustomAPIException(ErrorMessages.GAME_NOT_FOUND)
+
+        user = cast(User, request.user)
+        now = timezone.now()
+        affinity, created = UserGameAffinity.objects.update_or_create(
+            user=user,
+            game_id=game_id,
+            defaults={
+                "last_interacted_at": now,
+                "calculated_at": now,
+            },
+        )
+
+        logs_to_create = []
+
+        if "is_saved" in data:
+            old_saved = affinity.is_saved
+            affinity.is_saved = data["is_saved"]
+            if old_saved and not data["is_saved"]:
+                logs_to_create.append(
+                    InteractionLog(
+                        user=user,
+                        game_id=game_id,
+                        type=InteractionLog.ActionType.SAVED_REMOVE,
+                        source=InteractionLog.SourceType.DETAIL_PAGE,
+                    )
+                )
+            elif not old_saved and data["is_saved"]:
+                logs_to_create.append(
+                    InteractionLog(
+                        user=user,
+                        game_id=game_id,
+                        type=InteractionLog.ActionType.SAVED_ADD,
+                        source=InteractionLog.SourceType.DETAIL_PAGE,
+                    )
+                )
+
+        if "reaction" in data:
+            reaction_map = {"like": 1, "dislike": -1, "neutral": 0}
+            new_state = reaction_map[data["reaction"]]
+            old_state = affinity.like_state
+            affinity.like_state = new_state
+            if old_state != new_state:
+                if new_state == 1:
+                    logs_to_create.append(
+                        InteractionLog(
+                            user=user,
+                            game_id=game_id,
+                            type=InteractionLog.ActionType.LIKE,
+                            source=InteractionLog.SourceType.DETAIL_PAGE,
+                        )
+                    )
+                elif new_state == -1:
+                    logs_to_create.append(
+                        InteractionLog(
+                            user=user,
+                            game_id=game_id,
+                            type=InteractionLog.ActionType.DISLIKE,
+                            source=InteractionLog.SourceType.DETAIL_PAGE,
+                        )
+                    )
+
+        with transaction.atomic():
+            affinity.save()
+            InteractionLog.objects.bulk_create(logs_to_create)
+
+        return Response(
+            {
+                "is_saved": affinity.is_saved,
+                "reaction": {1: "like", -1: "dislike", 0: "neutral"}[affinity.like_state],
+                "updated_at": affinity.updated_at,
+            },
+            status=200,
+        )

--- a/apps/preferences/views.py
+++ b/apps/preferences/views.py
@@ -99,10 +99,7 @@ class PreferenceGameReactionUpdateView(APIView):
     permission_classes = [IsAuthenticated]
 
     def put(self, request: Request, game_id: int) -> Response:
-        body = request.data or {}
-        if "reaction" in body and body.get("reaction") not in ("like", "dislike", "neutral"):
-            raise CustomAPIException(ErrorMessages.INVALID_REACTION)
-        req_serializer = PreferenceGameReactionUpdateSerializer(data=body, partial=True)
+        req_serializer = PreferenceGameReactionUpdateSerializer(data=request.data, partial=True)
         req_serializer.is_valid(raise_exception=True)
         data = req_serializer.validated_data
 

--- a/apps/preferences/views.py
+++ b/apps/preferences/views.py
@@ -72,7 +72,9 @@ class PreferenceMeTagsUpdateView(APIView):
         pref, _ = UserPreference.objects.get_or_create(user=request.user)
         with transaction.atomic():
             UserPreferenceTag.objects.filter(user_preference=pref).delete()
-            tags_to_create = [UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids]
+            tags_to_create = [
+                UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids
+            ]
             UserPreferenceTag.objects.bulk_create(tags_to_create)
 
         response_serializer = PreferenceMeResponseSerializer(request.user)

--- a/apps/preferences/views.py
+++ b/apps/preferences/views.py
@@ -72,10 +72,15 @@ class PreferenceMeTagsUpdateView(APIView):
         pref, _ = UserPreference.objects.get_or_create(user=request.user)
         with transaction.atomic():
             UserPreferenceTag.objects.filter(user_preference=pref).delete()
+<<<<<<< HEAD
             tags_to_create = [
                 UserPreferenceTag(user_preference=pref, tag_id=tid) for tid in tag_ids
             ]
             UserPreferenceTag.objects.bulk_create(tags_to_create)
+=======
+            for tid in tag_ids:
+                UserPreferenceTag.objects.create(user_preference=pref, tag_id=tid)
+>>>>>>> 4a1f153 (fix: transaction.atomic 적용)
 
         response_serializer = PreferenceMeResponseSerializer(request.user)
         return Response(response_serializer.data)

--- a/apps/preferences/views.py
+++ b/apps/preferences/views.py
@@ -99,7 +99,10 @@ class PreferenceGameReactionUpdateView(APIView):
     permission_classes = [IsAuthenticated]
 
     def put(self, request: Request, game_id: int) -> Response:
-        req_serializer = PreferenceGameReactionUpdateSerializer(data=request.data, partial=True)
+        body = request.data or {}
+        if "reaction" in body and body.get("reaction") not in ("like", "dislike", "neutral"):
+            raise CustomAPIException(ErrorMessages.INVALID_REACTION)
+        req_serializer = PreferenceGameReactionUpdateSerializer(data=body, partial=True)
         req_serializer.is_valid(raise_exception=True)
         data = req_serializer.validated_data
 
@@ -172,6 +175,7 @@ class PreferenceGameReactionUpdateView(APIView):
 
         return Response(
             {
+                "game_id": game_id,
                 "is_saved": affinity.is_saved,
                 "reaction": {1: "like", -1: "dislike", 0: "neutral"}[affinity.like_state],
                 "updated_at": affinity.updated_at,


### PR DESCRIPTION
## ✅ PR 요약
- PUT /preferences/games/{game_id}/ API 추가 (게임 찜·좋아요·싫어요 설정)

## 📄 상세 내용
- [x] PreferenceGameReactionUpdateSerializer 추가 (is_saved, reaction 검증)
- [x] PreferenceGameReactionUpdateView 추가 (UserGameAffinity upsert, InteractionLog 기록)
- [x] path("games/<int:game_id>/", ...) URL 라우팅 추가

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] 빌드/린트가 통과합니다. (가능한 경우)

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
