### PR TITLE
api/v1/auth/refresh 엔드포인트를 구현

### DIFF
--- a/apps/users/tests/test_refresh.py
+++ b/apps/users/tests/test_refresh.py
@@ -1,5 +1,8 @@
 import datetime
+from datetime import timedelta
+from typing import cast
 
+from django.conf import settings
 from django.test import TestCase
 from rest_framework.test import APIClient
 
@@ -36,7 +39,15 @@ class RefreshAPITestCase(TestCase):
         self.assertIn("access_token", data)
         self.assertTrue(data["access_token"])
         self.assertEqual(data["token_type"], "Bearer")
-        self.assertEqual(data["expires_in"], 3600)
+        self.assertEqual(
+            data["expires_in"],
+            int(
+                cast(
+                    timedelta,
+                    settings.SIMPLE_JWT["ACCESS_TOKEN_LIFETIME"],
+                ).total_seconds()
+            ),
+        )
 
     def test_refresh_without_refresh_token(self) -> None:
         res = self.client.post(
@@ -59,3 +70,23 @@ class RefreshAPITestCase(TestCase):
         self.assertEqual(res.status_code, 401)
         data = res.json()
         self.assertEqual(data["code"], "INVALID_REFRESH_TOKEN")
+
+    def test_refresh_with_deactivated_user(self) -> None:
+        login_res = self.client.post(
+            "/api/v1/auth/login",
+            {"email": "admin@example.com", "password": "password1100110011"},
+            format="json",
+        )
+        self.assertEqual(login_res.status_code, 200)
+
+        self.user.is_active = False
+        self.user.save(update_fields=["is_active"])
+
+        res = self.client.post(
+            "/api/v1/auth/refresh",
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        self.assertEqual(data["code"], "ACCOUNT_DEACTIVATED")

--- a/apps/users/tests/test_refresh.py
+++ b/apps/users/tests/test_refresh.py
@@ -73,7 +73,7 @@ class RefreshAPITestCase(TestCase):
 
     def test_refresh_with_deactivated_user(self) -> None:
         login_res = self.client.post(
-            "/api/v1/auth/login",
+            "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
             format="json",
         )
@@ -83,7 +83,7 @@ class RefreshAPITestCase(TestCase):
         self.user.save(update_fields=["is_active"])
 
         res = self.client.post(
-            "/api/v1/auth/refresh",
+            "/api/v1/auth/refresh/",
             format="json",
         )
 

--- a/apps/users/tests/test_refresh.py
+++ b/apps/users/tests/test_refresh.py
@@ -1,0 +1,61 @@
+import datetime
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from apps.users.models.user import User
+
+
+class RefreshAPITestCase(TestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            email="admin@example.com",
+            nickname="admin",
+            birth_date=datetime.date(1997, 10, 2),
+            password="password1100110011",
+        )
+
+    def test_refresh(self) -> None:
+        login_res = self.client.post(
+            "/api/v1/auth/login/",
+            {"email": "admin@example.com", "password": "password1100110011"},
+            format="json",
+        )
+        self.assertEqual(login_res.status_code, 200)
+        self.assertIn("refresh_token", login_res.cookies)
+
+        res = self.client.post(
+            "/api/v1/auth/refresh/",
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, 200)
+
+        data = res.json()
+        self.assertIn("access_token", data)
+        self.assertTrue(data["access_token"])
+        self.assertEqual(data["token_type"], "Bearer")
+        self.assertEqual(data["expires_in"], 3600)
+
+    def test_refresh_without_refresh_token(self) -> None:
+        res = self.client.post(
+            "/api/v1/auth/refresh/",
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, 400)
+        data = res.json()
+        self.assertEqual(data["code"], "REFRESH_TOKEN_MISSING")
+
+    def test_refresh_with_invalid_refresh_token(self) -> None:
+        self.client.cookies["refresh_token"] = "invalid.token.value"
+
+        res = self.client.post(
+            "/api/v1/auth/refresh/",
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, 401)
+        data = res.json()
+        self.assertEqual(data["code"], "INVALID_REFRESH_TOKEN")

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from apps.users.views.auth import LoginAPIView, LogoutAPIView, SignupAPIView
+from apps.users.views.auth import LoginAPIView, SignupAPIView, RefreshAPIView, LogoutAPIView
 
 from .views.auth import EmailCodeSendAPIView
 
@@ -9,4 +9,5 @@ urlpatterns = [
     path("auth/email/code/", EmailCodeSendAPIView.as_view(), name="auth-email-code"),
     path("auth/login/", LoginAPIView.as_view(), name="auth-login"),
     path("auth/logout/", LogoutAPIView.as_view(), name="auth-logout"),
+    path("auth/refresh/", RefreshAPIView.as_view(), name="auth-refresh"),
 ]

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from apps.users.views.auth import LoginAPIView, SignupAPIView, RefreshAPIView, LogoutAPIView
+from apps.users.views.auth import LoginAPIView, LogoutAPIView, RefreshAPIView, SignupAPIView
 
 from .views.auth import EmailCodeSendAPIView
 

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -172,3 +172,46 @@ class LogoutAPIView(APIView):
         )
         response.delete_cookie("refresh_token")
         return response
+
+
+@extend_schema(
+    request=None,
+    responses={
+        200: OpenApiResponse(
+            response=inline_serializer(
+                name="RefreshSuccessResponse",
+                fields={
+                    "access_token": serializers.CharField(),
+                    "token_type": serializers.CharField(),
+                    "expires_in": serializers.IntegerField(),
+                },
+            )
+        )
+    },
+    tags=["auth"],
+)
+class RefreshAPIView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request: Request) -> Response:
+        refresh_token = request.COOKIES.get("refresh_token")
+        if not refresh_token:
+            raise CustomAPIException(ErrorMessages.REFRESH_TOKEN_MISSING)
+
+        try:
+            refresh = RefreshToken(refresh_token)  # type: ignore[arg-type]
+            access = refresh.access_token
+        except TokenError as err:
+            message = str(err)
+            if "expired" in message.lower():
+                raise CustomAPIException(ErrorMessages.REFRESH_TOKEN_EXPIRED) from err
+            raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN) from err
+
+        return Response(
+            {
+                "access_token": str(access),
+                "token_type": "Bearer",
+                "expires_in": int(access.lifetime.total_seconds()),
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -200,6 +200,15 @@ class RefreshAPIView(APIView):
 
         try:
             refresh = RefreshToken(refresh_token)  # type: ignore[arg-type]
+            User = get_user_model()
+            user_id = refresh.payload.get("user_id")
+            if user_id is None:
+                raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN)
+
+            user = User.objects.filter(id=int(user_id)).first()
+
+            if user is None or user.deleted_at is not None or user.is_active is False:
+                raise CustomAPIException(ErrorMessages.ACCOUNT_DEACTIVATED)
             access = refresh.access_token
         except TokenError as err:
             message = str(err)


### PR DESCRIPTION
## ✅ PR 요약
POST /api/v1/auth/refresh 엔드포인트를 구현했습니다.

## 📄 상세 내용
- refresh_token 쿠키를 기반으로 access token 재발급 API 추가
- 응답 형식을 login API와 동일하게 `access_token`, `token_type`, `expires_in`으로 구성
- Swagger 스키마 추가

## 🧪 테스트
- refresh 성공 케이스
- refresh_token 쿠키 누락 케이스
- 잘못된 refresh_token 케이스

## 📌 체크리스트
- [x] 로컬 테스트 통과
- [x] ruff check 통과
- [x] mypy 통과
