### PR TITLE
내정보 수정 API 구현

### DIFF
--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -1,5 +1,3 @@
-from typing import ClassVar
-
 from rest_framework import serializers
 
 from apps.core.exceptions.exception_handler import CustomAPIException
@@ -36,17 +34,18 @@ class UserMeUpdateResponseSerializer(serializers.ModelSerializer[User]):
 
 
 class UserMeUpdateRequestSerializer(serializers.ModelSerializer[User]):
+    nickname = serializers.CharField(
+        required=False,
+        max_length=30,
+        validators=[],
+    )
+
     class Meta:
         model = User
         fields = [
             "nickname",
             "birth_date",
         ]
-        extra_kwargs: ClassVar[dict[str, dict[str, list[object]]]] = {
-            "nickname": {
-                "validators": [],
-            },
-        }
 
     def validate_nickname(self, value: str) -> str:
         queryset = User.objects.filter(nickname=value)

--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -1,5 +1,9 @@
+from typing import ClassVar
+
 from rest_framework import serializers
 
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
 
 
@@ -17,3 +21,37 @@ class UserMeResponseSerializer(serializers.ModelSerializer[User]):
             "is_active",
             "created_at",
         ]
+
+
+class UserMeUpdateResponseSerializer(serializers.ModelSerializer[User]):
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "email",
+            "nickname",
+            "birth_date",
+            "updated_at",
+        ]
+
+
+class UserMeUpdateRequestSerializer(serializers.ModelSerializer[User]):
+    class Meta:
+        model = User
+        fields = [
+            "nickname",
+            "birth_date",
+        ]
+        extra_kwargs: ClassVar[dict[str, dict[str, list[object]]]] = {
+            "nickname": {
+                "validators": [],
+            },
+        }
+
+    def validate_nickname(self, value: str) -> str:
+        queryset = User.objects.filter(nickname=value)
+        if self.instance is not None:
+            queryset = queryset.exclude(pk=self.instance.pk)
+        if queryset.exists():
+            raise CustomAPIException(ErrorMessages.NICKNAME_ALREADY_EXISTS)
+        return value

--- a/apps/users/tests/test_user_me.py
+++ b/apps/users/tests/test_user_me.py
@@ -49,3 +49,75 @@ class UserMeRetrieveAPITest(TestCase):
         self.user.save(update_fields=["deleted_at"])
         res = client.get("/api/v1/users/me/")
         self.assertEqual(res.status_code, 404)
+
+    def test_patch_me_updates_user_info(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        res = client.patch(
+            "/api/v1/users/me/",
+            {
+                "nickname": "updated123",
+                "birth_date": "2000-02-02",
+            },
+            format="json",
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["nickname"], "updated123")
+        self.assertEqual(res.data["birth_date"], "2000-02-02")
+        self.assertTrue(res.data["updated_at"])
+
+    def test_patch_me_updates_only_provided_fields(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        res = client.patch(
+            "/api/v1/users/me/",
+            {
+                "nickname": "onlynickname",
+            },
+            format="json",
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["nickname"], "onlynickname")
+        self.assertEqual(res.data["birth_date"], "1999-01-01")
+
+    def test_patch_me_returns_401_when_not_authenticated(self) -> None:
+        res = self.client.patch(
+            "/api/v1/users/me/",
+            {
+                "nickname": "updated123",
+            },
+            format="json",
+        )
+        self.assertEqual(res.status_code, 401)
+
+    def test_patch_me_returns_409_when_nickname_already_exists(self) -> None:
+        get_user_model().objects.create_user(
+            email="other@example.com",
+            password="Passw0rd!",
+            nickname="duplicated",
+            birth_date=datetime.date(1998, 1, 1),
+        )
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        res = client.patch(
+            "/api/v1/users/me/",
+            {
+                "nickname": "duplicated",
+            },
+            format="json",
+        )
+        self.assertEqual(res.status_code, 409)
+
+    def test_patch_me_returns_400_when_birth_date_is_invalid(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        res = client.patch(
+            "/api/v1/users/me/",
+            {
+                "birth_date": "invalid-date",
+            },
+            format="json",
+        )
+        self.assertEqual(res.status_code, 400)

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from apps.users.views.auth import LoginAPIView, LogoutAPIView, RefreshAPIView, SignupAPIView
-from apps.users.views.me import UserMeRetrieveAPIView
+from apps.users.views.me import UserMeAPIView
 
 from .views.auth import EmailCodeSendAPIView
 
@@ -11,5 +11,5 @@ urlpatterns = [
     path("auth/login/", LoginAPIView.as_view(), name="auth-login"),
     path("auth/logout/", LogoutAPIView.as_view(), name="auth-logout"),
     path("auth/refresh/", RefreshAPIView.as_view(), name="auth-refresh"),
-    path("users/me/", UserMeRetrieveAPIView.as_view(), name="users-me"),
+    path("users/me/", UserMeAPIView.as_view(), name="users-me"),
 ]

--- a/apps/users/views/me.py
+++ b/apps/users/views/me.py
@@ -1,7 +1,7 @@
-from typing import cast
+from typing import Any, cast
 
 from drf_spectacular.utils import extend_schema
-from rest_framework import generics
+from rest_framework import generics, serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -17,7 +17,7 @@ from apps.users.serializers.me import (
 
 
 @extend_schema(tags=["Users"])
-class UserMeRetrieveAPIView(generics.RetrieveUpdateAPIView[User]):
+class UserMeAPIView(generics.RetrieveUpdateAPIView[User]):
     permission_classes = [IsAuthenticated]
     serializer_class = UserMeResponseSerializer
     http_method_names = ["get", "patch"]
@@ -28,9 +28,7 @@ class UserMeRetrieveAPIView(generics.RetrieveUpdateAPIView[User]):
             raise CustomAPIException(ErrorMessages.USER_NOT_FOUND)
         return user
 
-    def get_serializer_class(
-        self,
-    ) -> type[UserMeResponseSerializer] | type[UserMeUpdateRequestSerializer]:
+    def get_serializer_class(self) -> type[serializers.Serializer[Any]]:
         if self.request.method == "PATCH":
             return UserMeUpdateRequestSerializer
         return UserMeResponseSerializer

--- a/apps/users/views/me.py
+++ b/apps/users/views/me.py
@@ -3,24 +3,57 @@ from typing import cast
 from drf_spectacular.utils import extend_schema
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
-from apps.users.serializers.me import UserMeResponseSerializer
-
-
-@extend_schema(
-    tags=["Users"],
-    summary="내 정보 조회",
-    responses={200: UserMeResponseSerializer},
+from apps.users.serializers.me import (
+    UserMeResponseSerializer,
+    UserMeUpdateRequestSerializer,
+    UserMeUpdateResponseSerializer,
 )
-class UserMeRetrieveAPIView(generics.RetrieveAPIView[User]):
+
+
+@extend_schema(tags=["Users"])
+class UserMeRetrieveAPIView(generics.RetrieveUpdateAPIView[User]):
     permission_classes = [IsAuthenticated]
     serializer_class = UserMeResponseSerializer
+    http_method_names = ["get", "patch"]
 
     def get_object(self) -> User:
         user = cast(User, self.request.user)
         if user.deleted_at is not None:
             raise CustomAPIException(ErrorMessages.USER_NOT_FOUND)
         return user
+
+    def get_serializer_class(
+        self,
+    ) -> type[UserMeResponseSerializer] | type[UserMeUpdateRequestSerializer]:
+        if self.request.method == "PATCH":
+            return UserMeUpdateRequestSerializer
+        return UserMeResponseSerializer
+
+    @extend_schema(
+        summary="내 정보 조회",
+        responses={200: UserMeResponseSerializer},
+    )
+    def get(self, request: Request, *args: object, **kwargs: object) -> Response:
+        return super().retrieve(request, *args, **kwargs)
+
+    @extend_schema(
+        summary="내 정보 수정",
+        request=UserMeUpdateRequestSerializer,
+        responses={200: UserMeUpdateResponseSerializer},
+    )
+    def patch(self, request: Request, *args: object, **kwargs: object) -> Response:
+        return self.update(request, *args, **kwargs)
+
+    def update(self, request: Request, *args: object, **kwargs: object) -> Response:
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        updated_user = serializer.save()
+        response_serializer = UserMeUpdateResponseSerializer(updated_user)
+        return Response(response_serializer.data)


### PR DESCRIPTION
✅ PR 요약
PATCH /api/v1/users/me API 구현

📄 상세 내용
- 인증 사용자 대상 내 정보 수정 API(PATCH /api/v1/users/me) 구현
- nickname 중복 시 409 NICKNAME_ALREADY_EXISTS 반환
- 탈퇴 유저(deleted_at != null) 접근 불가 유지
- Swagger 문서에 GET / PATCH 스키마 분리 반영

🧪 테스트
- 내 정보 수정 성공
- 일부 필드만 수정 시 기존 값 유지
- 비인증 요청 401
- 중복 닉네임 요청 409
- 기존 users/me 조회 테스트 포함 전체 통과

📌 비고
- 400 VALIDATION_ERROR는 상태코드는 맞지만, 응답 형식은 프로젝트 공통 exception handler 이슈로 별도 정리 필요 가능성 있음
