### PR TITLE
feat: auth/me 엔드포인트 추가

### DIFF
--- a/apps/users/serializers/auth.py
+++ b/apps/users/serializers/auth.py
@@ -69,3 +69,14 @@ class LoginSerializer(serializers.Serializer[dict[str, Any]]):
 
         attrs["user"] = user
         return attrs
+
+
+class AuthMeResponseSerializer(serializers.ModelSerializer[User]):
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "email",
+            "is_active",
+            "is_adult_verified",
+        ]

--- a/apps/users/tests/test_auth_me.py
+++ b/apps/users/tests/test_auth_me.py
@@ -1,8 +1,10 @@
 import datetime
+from typing import cast
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
+from rest_framework.response import Response
 from rest_framework.test import APIClient
 
 from apps.core.exceptions.exception_message import ErrorMessages
@@ -19,15 +21,17 @@ class AuthMeAPITestCase(TestCase):
         )
 
     def test_auth_me_returns_current_user_info(self) -> None:
-        self.client.force_authenticate(user=self.user)
+        client = APIClient()
+        client.force_authenticate(user=self.user)
 
-        response = self.client.get("/api/v1/auth/me/")
+        res = client.get("/api/v1/auth/me/")
+        drf_res = cast(Response, res)
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["id"], self.user.id)
-        self.assertEqual(response.data["email"], self.user.email)
-        self.assertEqual(response.data["is_active"], self.user.is_active)
-        self.assertEqual(response.data["is_adult_verified"], self.user.is_adult_verified)
+        self.assertEqual(drf_res.status_code, 200)
+        self.assertEqual(drf_res.data["id"], self.user.id)
+        self.assertEqual(drf_res.data["email"], self.user.email)
+        self.assertEqual(drf_res.data["is_active"], self.user.is_active)
+        self.assertEqual(drf_res.data["is_adult_verified"], self.user.is_adult_verified)
 
     def test_auth_me_returns_401_when_not_authenticated(self) -> None:
         response = self.client.get("/api/v1/auth/me/")
@@ -35,21 +39,23 @@ class AuthMeAPITestCase(TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_auth_me_returns_401_when_user_is_deleted(self) -> None:
-        self.client.force_authenticate(user=self.user)
+        client = APIClient()
+        client.force_authenticate(user=self.user)
         self.user.deleted_at = timezone.now()
         self.user.save(update_fields=["deleted_at"])
 
-        response = self.client.get("/api/v1/auth/me/")
+        response = client.get("/api/v1/auth/me/")
 
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.json()["code"], ErrorMessages.ACCOUNT_DEACTIVATED.name)
 
     def test_auth_me_returns_401_when_user_is_inactive(self) -> None:
-        self.client.force_authenticate(user=self.user)
+        client = APIClient()
+        client.force_authenticate(user=self.user)
         self.user.is_active = False
         self.user.save(update_fields=["is_active"])
 
-        response = self.client.get("/api/v1/auth/me/")
+        response = client.get("/api/v1/auth/me/")
 
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.json()["code"], ErrorMessages.ACCOUNT_DEACTIVATED.name)

--- a/apps/users/tests/test_auth_me.py
+++ b/apps/users/tests/test_auth_me.py
@@ -3,6 +3,7 @@ from typing import cast
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.urls import reverse
 from django.utils import timezone
 from rest_framework.response import Response
 from rest_framework.test import APIClient
@@ -19,22 +20,28 @@ class AuthMeAPITestCase(TestCase):
             nickname="authmeuser",
             birth_date=datetime.date(1999, 1, 1),
         )
+        self.url = reverse("auth-me")
 
     def test_auth_me_returns_current_user_info(self) -> None:
         client = APIClient()
         client.force_authenticate(user=self.user)
 
-        res = client.get("/api/v1/auth/me/")
+        res = client.get(self.url)
         drf_res = cast(Response, res)
 
         self.assertEqual(drf_res.status_code, 200)
-        self.assertEqual(drf_res.data["id"], self.user.id)
-        self.assertEqual(drf_res.data["email"], self.user.email)
-        self.assertEqual(drf_res.data["is_active"], self.user.is_active)
-        self.assertEqual(drf_res.data["is_adult_verified"], self.user.is_adult_verified)
+        self.assertEqual(
+            drf_res.data,
+            {
+                "id": self.user.id,
+                "email": self.user.email,
+                "is_active": self.user.is_active,
+                "is_adult_verified": self.user.is_adult_verified,
+            },
+        )
 
     def test_auth_me_returns_401_when_not_authenticated(self) -> None:
-        response = self.client.get("/api/v1/auth/me/")
+        response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 401)
 
@@ -44,7 +51,7 @@ class AuthMeAPITestCase(TestCase):
         self.user.deleted_at = timezone.now()
         self.user.save(update_fields=["deleted_at"])
 
-        response = client.get("/api/v1/auth/me/")
+        response = client.get(self.url)
 
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.json()["code"], ErrorMessages.ACCOUNT_DEACTIVATED.name)
@@ -55,7 +62,7 @@ class AuthMeAPITestCase(TestCase):
         self.user.is_active = False
         self.user.save(update_fields=["is_active"])
 
-        response = client.get("/api/v1/auth/me/")
+        response = client.get(self.url)
 
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.json()["code"], ErrorMessages.ACCOUNT_DEACTIVATED.name)

--- a/apps/users/tests/test_auth_me.py
+++ b/apps/users/tests/test_auth_me.py
@@ -1,0 +1,55 @@
+import datetime
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from apps.core.exceptions.exception_message import ErrorMessages
+
+
+class AuthMeAPITestCase(TestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.user = get_user_model().objects.create_user(
+            email="authme@example.com",
+            password="Passw0rd!",
+            nickname="authmeuser",
+            birth_date=datetime.date(1999, 1, 1),
+        )
+
+    def test_auth_me_returns_current_user_info(self) -> None:
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get("/api/v1/auth/me/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["id"], self.user.id)
+        self.assertEqual(response.data["email"], self.user.email)
+        self.assertEqual(response.data["is_active"], self.user.is_active)
+        self.assertEqual(response.data["is_adult_verified"], self.user.is_adult_verified)
+
+    def test_auth_me_returns_401_when_not_authenticated(self) -> None:
+        response = self.client.get("/api/v1/auth/me/")
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_auth_me_returns_401_when_user_is_deleted(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        self.user.deleted_at = timezone.now()
+        self.user.save(update_fields=["deleted_at"])
+
+        response = self.client.get("/api/v1/auth/me/")
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["code"], ErrorMessages.ACCOUNT_DEACTIVATED.name)
+
+    def test_auth_me_returns_401_when_user_is_inactive(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        self.user.is_active = False
+        self.user.save(update_fields=["is_active"])
+
+        response = self.client.get("/api/v1/auth/me/")
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["code"], ErrorMessages.ACCOUNT_DEACTIVATED.name)

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from apps.users.views.auth import LoginAPIView, LogoutAPIView, RefreshAPIView, SignupAPIView
+from apps.users.views.auth import AuthMeAPIView, LoginAPIView, LogoutAPIView, RefreshAPIView, SignupAPIView
 from apps.users.views.me import UserMeAPIView
 
 from .views.auth import EmailCodeSendAPIView
@@ -11,5 +11,6 @@ urlpatterns = [
     path("auth/login/", LoginAPIView.as_view(), name="auth-login"),
     path("auth/logout/", LogoutAPIView.as_view(), name="auth-logout"),
     path("auth/refresh/", RefreshAPIView.as_view(), name="auth-refresh"),
+    path("auth/me/", AuthMeAPIView.as_view(), name="auth-me"),
     path("users/me/", UserMeAPIView.as_view(), name="users-me"),
 ]

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -16,6 +16,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
+from apps.users.models.user import User
 from apps.users.serializers.auth import (
     AuthMeResponseSerializer,
     EmailCodeSendRequestSerializer,
@@ -252,7 +253,7 @@ class AuthMeAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request: Request) -> Response:
-        user = cast(get_user_model(), request.user)
+        user = cast(User, request.user)
 
         if user.deleted_at is not None or user.is_active is False:
             raise CustomAPIException(ErrorMessages.ACCOUNT_DEACTIVATED)

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -1,4 +1,5 @@
 import secrets
+from typing import cast
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -16,6 +17,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.serializers.auth import (
+    AuthMeResponseSerializer,
     EmailCodeSendRequestSerializer,
     LoginSerializer,
     SignupRequestSerializer,
@@ -238,3 +240,21 @@ class RefreshAPIView(APIView):
             },
             status=status.HTTP_200_OK,
         )
+
+
+@extend_schema(
+    summary="현재 인증 사용자 조회",
+    request=None,
+    responses={200: AuthMeResponseSerializer},
+    tags=["auth"],
+)
+class AuthMeAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        user = cast(get_user_model(), request.user)
+
+        if user.deleted_at is not None or user.is_active is False:
+            raise CustomAPIException(ErrorMessages.ACCOUNT_DEACTIVATED)
+
+        return Response(AuthMeResponseSerializer(user).data, status=status.HTTP_200_OK)

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -255,7 +255,7 @@ class AuthMeAPIView(APIView):
     def get(self, request: Request) -> Response:
         user = cast(User, request.user)
 
-        if user.deleted_at is not None or user.is_active is False:
+        if user.deleted_at is not None or not user.is_active:
             raise CustomAPIException(ErrorMessages.ACCOUNT_DEACTIVATED)
 
         return Response(AuthMeResponseSerializer(user).data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 인증된 사용자의 최소 정보와 토큰 유효 상태를 확인할 수 있는 `GET /api/v1/auth/me/` 엔드포인트를 추가했습니다.

## 📄 상세 내용
-  `AuthMeAPIView`를 추가하고 `GET /api/v1/auth/me/` 라우트를 연결했습니다.
-  `id`, `email`, `is_active`, `is_adult_verified`를 반환하는 `AuthMeResponseSerializer`를 추가했습니다.
-  삭제되었거나 비활성화된 사용자는 `401 ACCOUNT_DEACTIVATED`를 반환하도록 테스트를 추가했습니다.

## 🧪 테스트
- 로컬에서 확인했습니다.

