### PR TITLE
[Feature/codex/auth-users-service-split] auth/users 서비스 레이어 분리

### DIFF
--- a/apps/users/serializers/auth.py
+++ b/apps/users/serializers/auth.py
@@ -1,74 +1,50 @@
-from typing import Any
-
-from django.contrib.auth.password_validation import validate_password
-from django.core.cache import cache
-from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 
-from apps.core.exceptions.exception_handler import CustomAPIException
-from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
 
 
-class SignupRequestSerializer(serializers.Serializer[dict[str, Any]]):
+class SignupRequestSerializer(serializers.Serializer[dict[str, object]]):
     email = serializers.EmailField()
     code = serializers.CharField(min_length=6, max_length=6)
     password = serializers.CharField(write_only=True)
     nickname = serializers.CharField()
     birth_date = serializers.DateField()
 
-    def validate_email(self, value: str) -> str:
-        if User.objects.filter(email=value).exists():
-            raise CustomAPIException(ErrorMessages.EMAIL_ALREADY_EXISTS)
-        return value
 
-    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        email = attrs["email"]
-        code = attrs["code"]
-
-        key = f"email_code:{email}"
-        saved_code = cache.get(key)
-
-        if saved_code is None:
-            raise CustomAPIException(ErrorMessages.CODE_EXPIRED)
-
-        if str(saved_code) != code:
-            raise CustomAPIException(ErrorMessages.INVALID_CODE)
-
-        return attrs
-
-    def validate_password(self, value: str) -> str:
-        try:
-            validate_password(value)
-        except DjangoValidationError as err:
-            raise CustomAPIException(ErrorMessages.VALIDATION_ERROR) from err
-        return value
+class SignupResponseSerializer(serializers.ModelSerializer[User]):
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "email",
+            "nickname",
+            "birth_date",
+            "created_at",
+        ]
 
 
 class EmailCodeSendRequestSerializer(serializers.Serializer):  # type: ignore[type-arg]
     email = serializers.EmailField(required=True)
 
 
-class LoginSerializer(serializers.Serializer[dict[str, Any]]):
+class EmailCodeSendResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    message = serializers.CharField()
+    expires_in = serializers.IntegerField()
+
+
+class LoginRequestSerializer(serializers.Serializer[dict[str, object]]):
     email = serializers.EmailField(required=True)
     password = serializers.CharField(write_only=True)
 
-    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        email = attrs["email"]
-        password = attrs["password"]
 
-        user = User.objects.filter(email=email).first()
-        if user is None:
-            raise CustomAPIException(ErrorMessages.INVALID_CREDENTIALS)
+class TokenResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    access_token = serializers.CharField()
+    token_type = serializers.CharField()
+    expires_in = serializers.IntegerField()
 
-        if user.deleted_at is not None or user.is_active is False:
-            raise CustomAPIException(ErrorMessages.ACCOUNT_DEACTIVATED)
 
-        if not user.check_password(password):
-            raise CustomAPIException(ErrorMessages.INVALID_CREDENTIALS)
-
-        attrs["user"] = user
-        return attrs
+class LogoutResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    message = serializers.CharField()
 
 
 class AuthMeResponseSerializer(serializers.ModelSerializer[User]):

--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -1,7 +1,5 @@
 from rest_framework import serializers
 
-from apps.core.exceptions.exception_handler import CustomAPIException
-from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
 
 
@@ -33,24 +31,6 @@ class UserMeUpdateResponseSerializer(serializers.ModelSerializer[User]):
         ]
 
 
-class UserMeUpdateRequestSerializer(serializers.ModelSerializer[User]):
-    nickname = serializers.CharField(
-        required=False,
-        max_length=30,
-        validators=[],
-    )
-
-    class Meta:
-        model = User
-        fields = [
-            "nickname",
-            "birth_date",
-        ]
-
-    def validate_nickname(self, value: str) -> str:
-        queryset = User.objects.filter(nickname=value)
-        if self.instance is not None:
-            queryset = queryset.exclude(pk=self.instance.pk)
-        if queryset.exists():
-            raise CustomAPIException(ErrorMessages.NICKNAME_ALREADY_EXISTS)
-        return value
+class UserMeUpdateRequestSerializer(serializers.Serializer[dict[str, object]]):
+    nickname = serializers.CharField(required=False, max_length=30)
+    birth_date = serializers.DateField(required=False)

--- a/apps/users/services/__init__.py
+++ b/apps/users/services/__init__.py
@@ -1,0 +1,22 @@
+from .auth_service import (
+    authenticate_user,
+    get_active_user_or_deactivated,
+    issue_auth_tokens,
+    logout_user,
+    refresh_access_token,
+    send_signup_email_code,
+    signup_user,
+)
+from .user_me_service import get_user_me, update_user_me
+
+__all__ = [
+    "authenticate_user",
+    "get_active_user_or_deactivated",
+    "get_user_me",
+    "issue_auth_tokens",
+    "logout_user",
+    "refresh_access_token",
+    "send_signup_email_code",
+    "signup_user",
+    "update_user_me",
+]

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -49,6 +49,8 @@ def send_signup_email_code(email: str) -> int:
 def signup_user(*, email: str, code: str, password: str, nickname: str, birth_date: date) -> User:
     if User.objects.filter(email=email).exists():
         raise CustomAPIException(ErrorMessages.EMAIL_ALREADY_EXISTS)
+    if User.objects.filter(nickname=nickname).exists():
+        raise CustomAPIException(ErrorMessages.NICKNAME_ALREADY_EXISTS)
 
     saved_code = cache.get(f"email_code:{email}")
     if saved_code is None:
@@ -113,7 +115,7 @@ def refresh_access_token(refresh_token: str | None) -> tuple[str, int]:
 
         user = User.objects.filter(id=int(user_id)).first()
         if user is None:
-            raise CustomAPIException(ErrorMessages.ACCOUNT_DEACTIVATED)
+            raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN)
         get_active_user_or_deactivated(user)
 
         access = refresh.access_token

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import secrets
+from datetime import date
+
+from django.conf import settings
+from django.contrib.auth.password_validation import validate_password
+from django.core.cache import cache
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.mail import send_mail
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.users.models.user import User
+
+EMAIL_CODE_TTL_SECONDS = 300
+EMAIL_CODE_COOLDOWN_SECONDS = 60
+
+
+def get_active_user_or_deactivated(user: User) -> User:
+    if user.deleted_at is not None or not user.is_active:
+        raise CustomAPIException(ErrorMessages.ACCOUNT_DEACTIVATED)
+    return user
+
+
+def send_signup_email_code(email: str) -> int:
+    if User.objects.filter(email=email).exists():
+        raise CustomAPIException(ErrorMessages.EMAIL_ALREADY_EXISTS)
+
+    cooldown_key = f"email_code_cooldown:{email}"
+    if cache.get(cooldown_key):
+        raise CustomAPIException(ErrorMessages.TOO_MANY_REQUESTS)
+
+    code = f"{secrets.randbelow(1000000):06d}"
+    cache.set(cooldown_key, True, timeout=EMAIL_CODE_COOLDOWN_SECONDS)
+    cache.set(f"email_code:{email}", code, timeout=EMAIL_CODE_TTL_SECONDS)
+    send_mail(
+        subject="[Gechu] 이메일 인증 코드",
+        message=f"인증 코드: {code}\n이 코드는 {EMAIL_CODE_TTL_SECONDS // 60}분 동안 유효합니다.",
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[email],
+        fail_silently=False,
+    )
+    return EMAIL_CODE_TTL_SECONDS
+
+
+def signup_user(*, email: str, code: str, password: str, nickname: str, birth_date: date) -> User:
+    if User.objects.filter(email=email).exists():
+        raise CustomAPIException(ErrorMessages.EMAIL_ALREADY_EXISTS)
+
+    saved_code = cache.get(f"email_code:{email}")
+    if saved_code is None:
+        raise CustomAPIException(ErrorMessages.CODE_EXPIRED)
+    if str(saved_code) != code:
+        raise CustomAPIException(ErrorMessages.INVALID_CODE)
+
+    try:
+        validate_password(password)
+    except DjangoValidationError as err:
+        raise CustomAPIException(ErrorMessages.VALIDATION_ERROR) from err
+
+    user = User.objects.create_user(
+        email=email,
+        password=password,
+        nickname=nickname,
+        birth_date=birth_date,
+    )
+    cache.delete(f"email_code:{email}")
+    return user
+
+
+def authenticate_user(*, email: str, password: str) -> User:
+    user = User.objects.filter(email=email).first()
+    if user is None:
+        raise CustomAPIException(ErrorMessages.INVALID_CREDENTIALS)
+
+    get_active_user_or_deactivated(user)
+
+    if not user.check_password(password):
+        raise CustomAPIException(ErrorMessages.INVALID_CREDENTIALS)
+
+    return user
+
+
+def issue_auth_tokens(user: User) -> tuple[str, str, int]:
+    refresh = RefreshToken.for_user(user)
+    access = refresh.access_token
+    return str(access), str(refresh), int(access.lifetime.total_seconds())
+
+
+def logout_user(refresh_token: str | None) -> None:
+    if not refresh_token:
+        raise CustomAPIException(ErrorMessages.REFRESH_TOKEN_MISSING)
+
+    try:
+        refresh = RefreshToken(refresh_token)  # type: ignore[arg-type]
+        refresh.blacklist()
+    except TokenError as err:
+        raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN) from err
+
+
+def refresh_access_token(refresh_token: str | None) -> tuple[str, int]:
+    if not refresh_token:
+        raise CustomAPIException(ErrorMessages.REFRESH_TOKEN_MISSING)
+
+    try:
+        refresh = RefreshToken(refresh_token)  # type: ignore[arg-type]
+        user_id = refresh.payload.get("user_id")
+        if user_id is None:
+            raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN)
+
+        user = User.objects.filter(id=int(user_id)).first()
+        if user is None:
+            raise CustomAPIException(ErrorMessages.ACCOUNT_DEACTIVATED)
+        get_active_user_or_deactivated(user)
+
+        access = refresh.access_token
+    except TokenError as err:
+        message = str(err)
+        if "expired" in message.lower():
+            raise CustomAPIException(ErrorMessages.REFRESH_TOKEN_EXPIRED) from err
+        raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN) from err
+
+    return str(access), int(access.lifetime.total_seconds())

--- a/apps/users/services/user_me_service.py
+++ b/apps/users/services/user_me_service.py
@@ -15,20 +15,17 @@ def get_user_me(user: User) -> User:
 
 def update_user_me(user: User, *, nickname: str | None = None, birth_date: date | None = None) -> User:
     user = get_user_me(user)
+    update_fields: list[str] = []
 
     if nickname is not None:
         queryset = User.objects.filter(nickname=nickname).exclude(pk=user.pk)
         if queryset.exists():
             raise CustomAPIException(ErrorMessages.NICKNAME_ALREADY_EXISTS)
         user.nickname = nickname
+        update_fields.append("nickname")
 
     if birth_date is not None:
         user.birth_date = birth_date
-
-    update_fields: list[str] = []
-    if nickname is not None:
-        update_fields.append("nickname")
-    if birth_date is not None:
         update_fields.append("birth_date")
 
     if update_fields:

--- a/apps/users/services/user_me_service.py
+++ b/apps/users/services/user_me_service.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import date
+
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.users.models.user import User
+
+
+def get_user_me(user: User) -> User:
+    if user.deleted_at is not None:
+        raise CustomAPIException(ErrorMessages.USER_NOT_FOUND)
+    return user
+
+
+def update_user_me(user: User, *, nickname: str | None = None, birth_date: date | None = None) -> User:
+    user = get_user_me(user)
+
+    if nickname is not None:
+        queryset = User.objects.filter(nickname=nickname).exclude(pk=user.pk)
+        if queryset.exists():
+            raise CustomAPIException(ErrorMessages.NICKNAME_ALREADY_EXISTS)
+        user.nickname = nickname
+
+    if birth_date is not None:
+        user.birth_date = birth_date
+
+    update_fields: list[str] = []
+    if nickname is not None:
+        update_fields.append("nickname")
+    if birth_date is not None:
+        update_fields.append("birth_date")
+
+    if update_fields:
+        user.save(update_fields=update_fields + ["updated_at"])
+
+    return user

--- a/apps/users/tests/test_email_code_send.py
+++ b/apps/users/tests/test_email_code_send.py
@@ -11,11 +11,10 @@ class EmailCodeSendAPITest(TestCase):
     def setUp(self) -> None:
         self.client = APIClient()
         self.email = "user@example.com"
-        # 테스트 간 간섭 방지
         cache.delete(f"email_code:{self.email}")
         cache.delete(f"email_code_cooldown:{self.email}")
 
-    @patch("apps.users.views.auth.send_mail")
+    @patch("apps.users.services.auth_service.send_mail")
     def test_send_email_code_stores_code_in_cache(self, mock_send_mail: MagicMock) -> None:
         res = self.client.post(
             "/api/v1/auth/email/code/",

--- a/apps/users/tests/test_logout.py
+++ b/apps/users/tests/test_logout.py
@@ -17,7 +17,6 @@ class LogoutAPITestCase(TestCase):
         )
 
     def test_logout(self) -> None:
-        # 로그인 요청
         login_res = self.client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
@@ -32,7 +31,6 @@ class LogoutAPITestCase(TestCase):
         access_token = data["access_token"]
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
 
-        # 로그아웃 요청
         logout_res = self.client.post(
             "/api/v1/auth/logout/",
             format="json",

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -1,34 +1,38 @@
-import secrets
 from typing import cast
 
-from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.core.cache import cache
-from django.core.mail import send_mail
-from drf_spectacular.utils import OpenApiResponse, extend_schema, inline_serializer
-from rest_framework import serializers, status
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework_simplejwt.exceptions import TokenError
-from rest_framework_simplejwt.tokens import RefreshToken
 
-from apps.core.exceptions.exception_handler import CustomAPIException
-from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
 from apps.users.serializers.auth import (
     AuthMeResponseSerializer,
     EmailCodeSendRequestSerializer,
-    LoginSerializer,
+    EmailCodeSendResponseSerializer,
+    LoginRequestSerializer,
+    LogoutResponseSerializer,
     SignupRequestSerializer,
+    SignupResponseSerializer,
+    TokenResponseSerializer,
+)
+from apps.users.services import (
+    authenticate_user,
+    get_active_user_or_deactivated,
+    issue_auth_tokens,
+    logout_user,
+    refresh_access_token,
+    send_signup_email_code,
+    signup_user,
 )
 
 
 @extend_schema(
     summary="회원가입",
     request=SignupRequestSerializer,
-    responses={201: None},
+    responses={201: SignupResponseSerializer},
     tags=["auth"],
 )
 class SignupAPIView(APIView):
@@ -38,114 +42,57 @@ class SignupAPIView(APIView):
         serializer = SignupRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        data = serializer.validated_data
-        User = get_user_model()
-
-        user = User.objects.create_user(
-            email=data["email"],
-            password=data["password"],
-            nickname=data["nickname"],
-            birth_date=data["birth_date"],
-        )
-
-        cache.delete(f"email_code:{data['email']}")
-
-        return Response(
-            {
-                "id": user.id,
-                "email": user.email,
-                "nickname": user.nickname,
-                "birth_date": str(user.birth_date),
-                "created_at": user.created_at.isoformat().replace("+00:00", "Z")
-                if getattr(user, "created_at", None)
-                else None,
-            },
-            status=status.HTTP_201_CREATED,
-        )
+        user = signup_user(**serializer.validated_data)
+        return Response(SignupResponseSerializer(user).data, status=status.HTTP_201_CREATED)
 
 
 @extend_schema(
     summary="이메일 인증 코드 발송",
     request=EmailCodeSendRequestSerializer,
-    responses={201: None},
+    responses={201: EmailCodeSendResponseSerializer},
     tags=["auth"],
 )
 class EmailCodeSendAPIView(APIView):
     permission_classes = [AllowAny]
 
-    CODE_TTL_SECONDS = 300
-    COOLDOWN_SECONDS = 60
-
     def post(self, request: Request) -> Response:
         serializer = EmailCodeSendRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        email: str = serializer.validated_data["email"]
-
-        User = get_user_model()
-        if User.objects.filter(email=email).exists():
-            raise CustomAPIException(ErrorMessages.EMAIL_ALREADY_EXISTS)
-
-        cooldown_key = f"email_code_cooldown:{email}"
-        if cache.get(cooldown_key):
-            raise CustomAPIException(ErrorMessages.TOO_MANY_REQUESTS)
-
-        code = f"{secrets.randbelow(1000000):06d}"
-        cache.set(cooldown_key, True, timeout=self.COOLDOWN_SECONDS)
-        cache.set(f"email_code:{email}", code, timeout=self.CODE_TTL_SECONDS)
-        send_mail(
-            subject="[Gechu] 이메일 인증 코드",
-            message=(f"인증 코드: {code}\n이 코드는 {self.CODE_TTL_SECONDS // 60}분 동안 유효합니다."),
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[email],
-            fail_silently=False,
+        expires_in = send_signup_email_code(serializer.validated_data["email"])
+        response_serializer = EmailCodeSendResponseSerializer(
+            {"message": "인증 코드가 발송되었습니다.", "expires_in": expires_in}
         )
-        return Response(
-            {"message": "인증 코드가 발송되었습니다.", "expires_in": self.CODE_TTL_SECONDS},
-            status=status.HTTP_201_CREATED,
-        )
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
 
 @extend_schema(
     summary="로그인",
-    request=LoginSerializer,
-    responses={
-        200: OpenApiResponse(
-            response=inline_serializer(
-                name="LoginSuccessResponse",
-                fields={
-                    "access_token": serializers.CharField(),
-                    "token_type": serializers.CharField(),
-                    "expires_in": serializers.IntegerField(),
-                },
-            )
-        )
-    },
+    request=LoginRequestSerializer,
+    responses={200: TokenResponseSerializer},
     tags=["auth"],
 )
 class LoginAPIView(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request: Request) -> Response:
-        serializer = LoginSerializer(data=request.data)
+        serializer = LoginRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        user = serializer.validated_data["user"]
+        user = authenticate_user(**serializer.validated_data)
+        access_token, refresh_token, expires_in = issue_auth_tokens(user)
 
-        refresh = RefreshToken.for_user(user)
-        access = refresh.access_token
-
-        response = Response(
+        response_serializer = TokenResponseSerializer(
             {
-                "access_token": str(access),
+                "access_token": access_token,
                 "token_type": "Bearer",
-                "expires_in": int(access.lifetime.total_seconds()),
-            },
-            status=status.HTTP_200_OK,
+                "expires_in": expires_in,
+            }
         )
+        response = Response(response_serializer.data, status=status.HTTP_200_OK)
         response.set_cookie(
             key="refresh_token",
-            value=str(refresh),
+            value=refresh_token,
             httponly=True,
             samesite="Lax",
         )
@@ -155,37 +102,17 @@ class LoginAPIView(APIView):
 @extend_schema(
     summary="로그아웃",
     request=None,
-    responses={
-        200: OpenApiResponse(
-            response=inline_serializer(
-                name="LogoutSuccessResponse",
-                fields={
-                    "message": serializers.CharField(),
-                },
-            )
-        )
-    },
+    responses={200: LogoutResponseSerializer},
     tags=["auth"],
 )
 class LogoutAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request: Request) -> Response:
-        refresh_token = request.COOKIES.get("refresh_token")
+        logout_user(request.COOKIES.get("refresh_token"))
 
-        if not refresh_token:
-            raise CustomAPIException(ErrorMessages.REFRESH_TOKEN_MISSING)
-
-        try:
-            refresh = RefreshToken(refresh_token)  # type: ignore[arg-type]
-            refresh.blacklist()
-        except TokenError as err:
-            raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN) from err
-
-        response = Response(
-            {"message": "로그아웃 되었습니다."},
-            status=status.HTTP_200_OK,
-        )
+        response_serializer = LogoutResponseSerializer({"message": "로그아웃 되었습니다."})
+        response = Response(response_serializer.data, status=status.HTTP_200_OK)
         response.delete_cookie("refresh_token")
         return response
 
@@ -193,54 +120,22 @@ class LogoutAPIView(APIView):
 @extend_schema(
     summary="액세스 토큰 재발급",
     request=None,
-    responses={
-        200: OpenApiResponse(
-            response=inline_serializer(
-                name="RefreshSuccessResponse",
-                fields={
-                    "access_token": serializers.CharField(),
-                    "token_type": serializers.CharField(),
-                    "expires_in": serializers.IntegerField(),
-                },
-            )
-        )
-    },
+    responses={200: TokenResponseSerializer},
     tags=["auth"],
 )
 class RefreshAPIView(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request: Request) -> Response:
-        refresh_token = request.COOKIES.get("refresh_token")
-        if not refresh_token:
-            raise CustomAPIException(ErrorMessages.REFRESH_TOKEN_MISSING)
-
-        try:
-            refresh = RefreshToken(refresh_token)  # type: ignore[arg-type]
-            User = get_user_model()
-            user_id = refresh.payload.get("user_id")
-            if user_id is None:
-                raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN)
-
-            user = User.objects.filter(id=int(user_id)).first()
-
-            if user is None or user.deleted_at is not None or user.is_active is False:
-                raise CustomAPIException(ErrorMessages.ACCOUNT_DEACTIVATED)
-            access = refresh.access_token
-        except TokenError as err:
-            message = str(err)
-            if "expired" in message.lower():
-                raise CustomAPIException(ErrorMessages.REFRESH_TOKEN_EXPIRED) from err
-            raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN) from err
-
-        return Response(
+        access_token, expires_in = refresh_access_token(request.COOKIES.get("refresh_token"))
+        response_serializer = TokenResponseSerializer(
             {
-                "access_token": str(access),
+                "access_token": access_token,
                 "token_type": "Bearer",
-                "expires_in": int(access.lifetime.total_seconds()),
-            },
-            status=status.HTTP_200_OK,
+                "expires_in": expires_in,
+            }
         )
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
 
 
 @extend_schema(
@@ -253,9 +148,5 @@ class AuthMeAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request: Request) -> Response:
-        user = cast(User, request.user)
-
-        if user.deleted_at is not None or not user.is_active:
-            raise CustomAPIException(ErrorMessages.ACCOUNT_DEACTIVATED)
-
+        user = get_active_user_or_deactivated(cast(User, request.user))
         return Response(AuthMeResponseSerializer(user).data, status=status.HTTP_200_OK)

--- a/apps/users/views/me.py
+++ b/apps/users/views/me.py
@@ -6,14 +6,13 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from apps.core.exceptions.exception_handler import CustomAPIException
-from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
 from apps.users.serializers.me import (
     UserMeResponseSerializer,
     UserMeUpdateRequestSerializer,
     UserMeUpdateResponseSerializer,
 )
+from apps.users.services import get_user_me, update_user_me
 
 
 @extend_schema(tags=["Users"])
@@ -23,10 +22,7 @@ class UserMeAPIView(generics.RetrieveUpdateAPIView[User]):
     http_method_names = ["get", "patch"]
 
     def get_object(self) -> User:
-        user = cast(User, self.request.user)
-        if user.deleted_at is not None:
-            raise CustomAPIException(ErrorMessages.USER_NOT_FOUND)
-        return user
+        return get_user_me(cast(User, self.request.user))
 
     def get_serializer_class(self) -> type[serializers.Serializer[Any]]:
         if self.request.method == "PATCH":
@@ -50,8 +46,8 @@ class UserMeAPIView(generics.RetrieveUpdateAPIView[User]):
 
     def update(self, request: Request, *args: object, **kwargs: object) -> Response:
         instance = self.get_object()
-        serializer = self.get_serializer(instance, data=request.data, partial=True)
+        serializer = self.get_serializer(data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
-        updated_user = serializer.save()
+        updated_user = update_user_me(instance, **serializer.validated_data)
         response_serializer = UserMeUpdateResponseSerializer(updated_user)
         return Response(response_serializer.data)


### PR DESCRIPTION
## ✅ PR 요약
- auth 및 users/me 영역의 비즈니스 로직을 service 레이어로 분리해 view-serializer-service 역할을 명확히 정리했습니다.

## 📄 상세 내용
- `apps/users/services/` 패키지를 추가하고 `auth_service.py`, `user_me_service.py`로 인증/내 정보 관련 비즈니스 로직을 분리했습니다.
- `auth` 관련 view에서 회원가입, 로그인, 이메일 인증 코드 발송, 로그아웃, 토큰 재발급, `auth/me` 로직을 service 호출 중심으로 정리했습니다.
- `users/me` 조회 및 수정 로직에서 삭제 사용자 판별과 닉네임 중복 검사, 업데이트 처리를 service로 이동하고 관련 테스트를 정리했습니다.

## 🧪 테스트
- 로컬에서 확인했습니다.
