### PR TITLE
[Feature/interactions/view] 게임 조회 행동 기록 API

### DIFF
--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any
+
+from rest_framework import serializers
+
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.interactions.models import InteractionLog
+
+
+class InteractionViewLogRequestSerializer(serializers.Serializer[dict[str, Any]]):
+    game_id = serializers.IntegerField(min_value=1)
+    source = serializers.CharField()  # type: ignore[assignment]
+    metadata = serializers.JSONField(required=False)
+
+    def validate_source(self, value: str) -> str:
+        valid_sources = {choice for choice, _ in InteractionLog.SourceType.choices}
+        if value not in valid_sources:
+            raise CustomAPIException(ErrorMessages.INVALID_SOURCE)
+        return value
+
+
+class InteractionViewLogResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    id = serializers.IntegerField()
+    type = serializers.CharField()
+    logged_at = serializers.DateTimeField()

--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -10,9 +10,14 @@ from apps.interactions.models import InteractionLog
 
 
 class InteractionViewLogRequestSerializer(serializers.Serializer[dict[str, Any]]):
-    game_id = serializers.IntegerField(min_value=1)
-    source = serializers.CharField()  # type: ignore[assignment]
+    game_id = serializers.IntegerField(min_value=1, required=False)
+    source = serializers.CharField(required=False)  # type: ignore[assignment]
     metadata = serializers.JSONField(required=False)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if attrs.get("game_id") is None or attrs.get("source") is None:
+            raise CustomAPIException(ErrorMessages.GAME_ID_OR_SOURCE_MISSING)
+        return attrs
 
     def validate_source(self, value: str) -> str:
         valid_sources = {choice for choice, _ in InteractionLog.SourceType.choices}
@@ -24,4 +29,4 @@ class InteractionViewLogRequestSerializer(serializers.Serializer[dict[str, Any]]
 class InteractionViewLogResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
     id = serializers.IntegerField()
     type = serializers.CharField()
-    logged_at = serializers.DateTimeField()
+    logged_at = serializers.DateTimeField(source="created_at")

--- a/apps/interactions/tests.py
+++ b/apps/interactions/tests.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from django.utils import timezone
 from rest_framework.test import APIClient
 
+from apps.games.models import Game
 from apps.interactions.models import InteractionContextRule, InteractionLog, InteractionWeightRule
 from apps.users.models import User
 
@@ -27,9 +28,7 @@ class InteractionViewLogCreateAPITestCase(TestCase):
             password="pw",
         )
 
-    def _create_game(self, **kwargs: Any) -> Any:
-        from apps.games.models import Game
-
+    def _create_game(self, **kwargs: Any) -> Game:
         defaults = {
             "rawg_id": 6001,
             "slug": "test-game",

--- a/apps/interactions/tests.py
+++ b/apps/interactions/tests.py
@@ -1,1 +1,251 @@
-# Create your tests here.
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, cast
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from apps.interactions.models import InteractionContextRule, InteractionLog, InteractionWeightRule
+from apps.users.models import User
+
+
+class InteractionViewLogCreateAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/interactions/view/"
+        self._create_view_rules()
+
+    def _create_user(self) -> User:
+        return User.objects.create_user(
+            email="user@ex.com",
+            nickname="user",
+            birth_date=date(1990, 1, 1),
+            password="pw",
+        )
+
+    def _create_game(self, **kwargs: Any) -> Any:
+        from apps.games.models import Game
+
+        defaults = {
+            "rawg_id": 6001,
+            "slug": "test-game",
+            "name": "Test Game",
+            "thumbnail_img_url": "https://example.com/thumb.jpg",
+            "website": "https://example.com",
+            "rawg_rating": 4.50,
+            "is_visible": True,
+        }
+        defaults.update(kwargs)
+        return Game.objects.create(**defaults)
+
+    def _create_view_rules(self) -> None:
+        InteractionWeightRule.objects.create(
+            interaction_type=InteractionWeightRule.ActionType.VIEW,
+            base_weight=0.20,
+            cooldown_seconds=150,
+            repeat_decay=0.900,
+            is_active=True,
+        )
+        InteractionContextRule.objects.bulk_create(
+            [
+                InteractionContextRule(
+                    interaction_source=InteractionContextRule.InteractionSource.LIST_PAGE, multiplier=0.90
+                ),
+                InteractionContextRule(
+                    interaction_source=InteractionContextRule.InteractionSource.DETAIL_PAGE, multiplier=1.20
+                ),
+                InteractionContextRule(
+                    interaction_source=InteractionContextRule.InteractionSource.SEARCH_RESULT, multiplier=1.10
+                ),
+                InteractionContextRule(
+                    interaction_source=InteractionContextRule.InteractionSource.RECOMMENDATION, multiplier=1.40
+                ),
+                InteractionContextRule(
+                    interaction_source=InteractionContextRule.InteractionSource.SAVED_PAGE, multiplier=1.30
+                ),
+                InteractionContextRule(
+                    interaction_source=InteractionContextRule.InteractionSource.ONBOARDING, multiplier=1.50
+                ),
+            ]
+        )
+
+    def test_interaction_view_unauthorized(self) -> None:
+        response = self.client.post(self.url, {"game_id": 1, "source": "detail_page"}, format="json")
+        self.assertEqual(response.status_code, 401)
+
+    def test_interaction_view_missing_required_returns_400(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(self.url, {"game_id": 1}, format="json")
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "GAME_ID_OR_SOURCE_MISSING")
+
+    def test_interaction_view_invalid_source_returns_400(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "source": "wrong_source"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "INVALID_SOURCE")
+
+    def test_interaction_view_game_not_found_returns_404(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": 999999, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "GAME_NOT_FOUND")
+
+    def test_interaction_view_success(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {
+                "game_id": game.id,
+                "source": "recommendation",
+                "metadata": {"page": 1},
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+
+        data = cast(dict[str, Any], response.data)
+        self.assertIn("id", data)
+        self.assertEqual(data["type"], "view")
+        self.assertIn("logged_at", data)
+
+        log = InteractionLog.objects.get(id=data["id"])
+        self.assertEqual(log.user_id, user.id)
+        self.assertEqual(log.game_id, game.id)
+        self.assertEqual(log.type, InteractionLog.ActionType.VIEW)
+        self.assertEqual(log.source, InteractionLog.SourceType.RECOMMENDATION)
+        self.assertIsNotNone(log.weight)
+        self.assertEqual(float(cast(Any, log.weight)), 0.28)
+
+    def test_interaction_view_cooldown_ignored_returns_200(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(InteractionLog.objects.count(), 1)
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 200)
+        data = cast(dict[str, Any], second.data)
+        self.assertEqual(data["type"], "view")
+        self.assertIn("logged_at", data)
+        self.assertEqual(InteractionLog.objects.count(), 1)
+
+    def test_interaction_view_recent_null_weight_log_is_not_reused_for_cooldown(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+        old_log = InteractionLog.objects.create(
+            user=user,
+            game=game,
+            type=InteractionLog.ActionType.VIEW,
+            source=InteractionLog.SourceType.DETAIL_PAGE,
+            weight=None,
+        )
+        InteractionLog.objects.filter(id=old_log.id).update(created_at=timezone.now())
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(InteractionLog.objects.count(), 2)
+
+    def test_interaction_view_missing_weight_rule_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+        InteractionWeightRule.objects.filter(interaction_type=InteractionWeightRule.ActionType.VIEW).delete()
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "INTERACTION_TYPE_NOT_FOUND")
+
+    def test_interaction_view_missing_source_rule_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+        InteractionContextRule.objects.filter(
+            interaction_source=InteractionContextRule.InteractionSource.DETAIL_PAGE
+        ).delete()
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "SOURCE_NOT_FOUND")
+
+    def test_interaction_view_repeat_decay_applied(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+        InteractionWeightRule.objects.filter(interaction_type=InteractionWeightRule.ActionType.VIEW).update(
+            cooldown_seconds=0,
+            repeat_decay=0.900,
+        )
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+        first_id = cast(dict[str, Any], first.data)["id"]
+        first_log = InteractionLog.objects.get(id=first_id)
+        self.assertIsNotNone(first_log.weight)
+        self.assertEqual(float(cast(Any, first_log.weight)), 0.24)  # 0.2 * 1.2 * 0.9^0
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 201)
+        second_id = cast(dict[str, Any], second.data)["id"]
+        second_log = InteractionLog.objects.get(id=second_id)
+        self.assertIsNotNone(second_log.weight)
+        self.assertEqual(float(cast(Any, second_log.weight)), 0.216)  # 0.2 * 1.2 * 0.9^1

--- a/apps/interactions/urls.py
+++ b/apps/interactions/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.interactions.views import InteractionViewLogCreateView
+
+urlpatterns = [
+    path("view/", InteractionViewLogCreateView.as_view(), name="interaction-view-create"),
+]

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -1,1 +1,218 @@
-# Create your views here.
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+from typing import cast
+
+from django.utils import timezone
+from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.core.serializers.error_serializer import ErrorResponseSerializer
+from apps.games.models import Game
+from apps.interactions.models import InteractionContextRule, InteractionLog, InteractionWeightRule
+from apps.interactions.serializers import (
+    InteractionViewLogRequestSerializer,
+    InteractionViewLogResponseSerializer,
+)
+from apps.users.models import User
+
+
+@extend_schema(
+    tags=["Interactions"],
+    summary="게임 조회 행동 기록",
+    description=(
+        "게임 조회(view) 행동을 기록합니다.\n\n"
+        "- 최초 기록 시: `201` + `logged=true`\n"
+        "- 쿨다운 내 중복 요청 시: 로그를 추가 생성하지 않고 `200`으로 기존 최근 로그를 반환합니다.\n"
+        "- 가중치는 `interaction_weight_rules`(type=view)와 "
+        "`interaction_context_rules`(source) 조합으로 계산됩니다."
+    ),
+    request=InteractionViewLogRequestSerializer,
+    examples=[
+        OpenApiExample(
+            "요청 예시",
+            value={
+                "game_id": 1,
+                "source": "recommendation",
+                "metadata": {"page": 1, "section": "home_reco"},
+            },
+            request_only=True,
+        ),
+        OpenApiExample(
+            "생성 응답 예시 (201)",
+            value={
+                "id": 101,
+                "type": "view",
+                "logged_at": "2026-03-11T08:30:00Z",
+            },
+            response_only=True,
+            status_codes=["201"],
+        ),
+        OpenApiExample(
+            "쿨다운 무시 응답 예시 (200)",
+            value={
+                "id": 101,
+                "type": "view",
+                "logged_at": "2026-03-11T08:30:00Z",
+            },
+            response_only=True,
+            status_codes=["200"],
+        ),
+    ],
+    responses={
+        200: InteractionViewLogResponseSerializer,
+        201: InteractionViewLogResponseSerializer,
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Bad Request",
+            examples=[
+                OpenApiExample(
+                    "필수값 누락",
+                    value={
+                        "status_code": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.status_code,
+                        "code": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.name,
+                        "message": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.message,
+                    },
+                ),
+                OpenApiExample(
+                    "source 값 오류",
+                    value={
+                        "status_code": ErrorMessages.INVALID_SOURCE.status_code,
+                        "code": ErrorMessages.INVALID_SOURCE.name,
+                        "message": ErrorMessages.INVALID_SOURCE.message,
+                    },
+                ),
+            ],
+        ),
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Unauthorized",
+            examples=[
+                OpenApiExample(
+                    "인증 필요",
+                    value={
+                        "status_code": ErrorMessages.UNAUTHORIZED.status_code,
+                        "code": ErrorMessages.UNAUTHORIZED.name,
+                        "message": ErrorMessages.UNAUTHORIZED.message,
+                    },
+                )
+            ],
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Not Found",
+            examples=[
+                OpenApiExample(
+                    "게임 없음",
+                    value={
+                        "status_code": ErrorMessages.GAME_NOT_FOUND.status_code,
+                        "code": ErrorMessages.GAME_NOT_FOUND.name,
+                        "message": ErrorMessages.GAME_NOT_FOUND.message,
+                    },
+                ),
+                OpenApiExample(
+                    "view 룰 없음",
+                    value={
+                        "status_code": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.status_code,
+                        "code": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.name,
+                        "message": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.message,
+                    },
+                ),
+                OpenApiExample(
+                    "source 룰 없음",
+                    value={
+                        "status_code": ErrorMessages.SOURCE_NOT_FOUND.status_code,
+                        "code": ErrorMessages.SOURCE_NOT_FOUND.name,
+                        "message": ErrorMessages.SOURCE_NOT_FOUND.message,
+                    },
+                ),
+            ],
+        ),
+    },
+)
+class InteractionViewLogCreateView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request) -> Response:
+        payload = request.data
+        if "game_id" not in payload or "source" not in payload:
+            raise CustomAPIException(ErrorMessages.GAME_ID_OR_SOURCE_MISSING)
+
+        serializer = InteractionViewLogRequestSerializer(data=payload)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        game = Game.objects.filter(id=data["game_id"], is_visible=True).first()
+        if game is None:
+            raise CustomAPIException(ErrorMessages.GAME_NOT_FOUND)
+
+        weight_rule = InteractionWeightRule.objects.filter(
+            interaction_type=InteractionLog.ActionType.VIEW,
+            is_active=True,
+        ).first()
+        if weight_rule is None:
+            raise CustomAPIException(ErrorMessages.INTERACTION_TYPE_NOT_FOUND)
+
+        context_rule = InteractionContextRule.objects.filter(
+            interaction_source=data["source"],
+        ).first()
+        if context_rule is None:
+            raise CustomAPIException(ErrorMessages.SOURCE_NOT_FOUND)
+
+        user = cast(User, request.user)
+        latest_reusable_log = (
+            InteractionLog.objects.filter(
+                user=user,
+                game=game,
+                type=InteractionLog.ActionType.VIEW,
+                weight__isnull=False,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if (
+            latest_reusable_log is not None
+            and weight_rule.cooldown_seconds > 0
+            and latest_reusable_log.created_at >= timezone.now() - timedelta(seconds=weight_rule.cooldown_seconds)
+        ):
+            return Response(
+                {
+                    "id": latest_reusable_log.id,
+                    "type": latest_reusable_log.type,
+                    "logged_at": latest_reusable_log.created_at,
+                },
+                status=200,
+            )
+
+        repeat_count = InteractionLog.objects.filter(
+            user=user,
+            game=game,
+            type=InteractionLog.ActionType.VIEW,
+        ).count()
+        weight: Decimal = (
+            weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**repeat_count)
+        ).quantize(Decimal("0.0001"))
+
+        log = InteractionLog.objects.create(
+            user=user,
+            game=game,
+            type=InteractionLog.ActionType.VIEW,
+            source=data["source"],
+            weight=weight,
+            metadata=data.get("metadata"),
+        )
+
+        return Response(
+            {
+                "id": log.id,
+                "type": log.type,
+                "logged_at": log.created_at,
+            },
+            status=201,
+        )

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -140,11 +140,7 @@ class InteractionViewLogCreateView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request: Request) -> Response:
-        payload = request.data
-        if "game_id" not in payload or "source" not in payload:
-            raise CustomAPIException(ErrorMessages.GAME_ID_OR_SOURCE_MISSING)
-
-        serializer = InteractionViewLogRequestSerializer(data=payload)
+        serializer = InteractionViewLogRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
@@ -181,14 +177,8 @@ class InteractionViewLogCreateView(APIView):
             and weight_rule.cooldown_seconds > 0
             and latest_reusable_log.created_at >= timezone.now() - timedelta(seconds=weight_rule.cooldown_seconds)
         ):
-            return Response(
-                {
-                    "id": latest_reusable_log.id,
-                    "type": latest_reusable_log.type,
-                    "logged_at": latest_reusable_log.created_at,
-                },
-                status=200,
-            )
+            response_serializer = InteractionViewLogResponseSerializer(latest_reusable_log)
+            return Response(response_serializer.data, status=200)
 
         repeat_count = InteractionLog.objects.filter(
             user=user,
@@ -208,11 +198,5 @@ class InteractionViewLogCreateView(APIView):
             metadata=data.get("metadata"),
         )
 
-        return Response(
-            {
-                "id": log.id,
-                "type": log.type,
-                "logged_at": log.created_at,
-            },
-            status=201,
-        )
+        response_serializer = InteractionViewLogResponseSerializer(log)
+        return Response(response_serializer.data, status=201)

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path("api/schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
     path("api/schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
     path("api/v1/preferences/", include("apps.preferences.urls")),
+    path("api/v1/interactions/", include("apps.interactions.urls")),
     path("admin/", admin.site.urls),
     path("api/v1/", include("apps.users.urls")),
     path("api/v1/games/", include("apps.games.urls")),


### PR DESCRIPTION
## ✅ PR 요약
- POST /api/v1/interactions/view/ 게임 조회 행동 기록 API를 추가했습니다.

## 📄 상세 내용
- [x]  인증 사용자 대상 `POST /api/v1/interactions/view/` 엔드포인트를 추가
- [x] `game_id`, `source`, `metadata` 요청 검증을 적용
- [x] 가중치 룰/컨텍스트 룰 기반으로 view 행동 기록 데이터를 저장하고, 쿨다운 내 중복 요청은 기존 기록을 반환합니다
- [x] repeat 기준은 (user, game, type) 로 적용했습니다

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] apps/interactions/tests.py에 케이스 추가
- [x] 빌드/린트가 통과합니다. (가능한 경우)

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
