### PR TITLE
[refactor] interactions/view 비즈니스 로직 service 분리

### DIFF
--- a/apps/interactions/services/__init__.py
+++ b/apps/interactions/services/__init__.py
@@ -1,0 +1,3 @@
+from .view_log_service import record_view_interaction
+
+__all__ = ["record_view_interaction"]

--- a/apps/interactions/services/view_log_service.py
+++ b/apps/interactions/services/view_log_service.py
@@ -71,9 +71,7 @@ def record_view_interaction(
         ).count()
         effective_repeat_count = min(repeat_count, 10)
         weight: Decimal = (
-            weight_rule.base_weight
-            * context_rule.multiplier
-            * (weight_rule.repeat_decay**effective_repeat_count)
+            weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**effective_repeat_count)
         ).quantize(Decimal("0.0001"))
 
         log = InteractionLog.objects.create(

--- a/apps/interactions/services/view_log_service.py
+++ b/apps/interactions/services/view_log_service.py
@@ -19,22 +19,23 @@ def record_view_interaction(
     source: str,
     metadata: dict[str, object] | list[object] | str | int | float | bool | None = None,
 ) -> tuple[InteractionLog, bool]:
-    game = Game.objects.filter(id=game_id, is_visible=True).first()
-    if game is None:
-        raise CustomAPIException(ErrorMessages.GAME_NOT_FOUND)
+    try:
+        game = Game.objects.get(id=game_id, is_visible=True)
+    except Game.DoesNotExist:
+        raise CustomAPIException(ErrorMessages.GAME_NOT_FOUND) from None
 
-    weight_rule = InteractionWeightRule.objects.filter(
-        interaction_type=InteractionLog.ActionType.VIEW,
-        is_active=True,
-    ).first()
-    if weight_rule is None:
-        raise CustomAPIException(ErrorMessages.INTERACTION_TYPE_NOT_FOUND)
+    try:
+        weight_rule = InteractionWeightRule.objects.get(
+            interaction_type=InteractionLog.ActionType.VIEW,
+            is_active=True,
+        )
+    except InteractionWeightRule.DoesNotExist:
+        raise CustomAPIException(ErrorMessages.INTERACTION_TYPE_NOT_FOUND) from None
 
-    context_rule = InteractionContextRule.objects.filter(
-        interaction_source=source,
-    ).first()
-    if context_rule is None:
-        raise CustomAPIException(ErrorMessages.SOURCE_NOT_FOUND)
+    try:
+        context_rule = InteractionContextRule.objects.get(interaction_source=source)
+    except InteractionContextRule.DoesNotExist:
+        raise CustomAPIException(ErrorMessages.SOURCE_NOT_FOUND) from None
 
     latest_reusable_log = (
         InteractionLog.objects.filter(

--- a/apps/interactions/services/view_log_service.py
+++ b/apps/interactions/services/view_log_service.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+
+from django.utils import timezone
+
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.games.models import Game
+from apps.interactions.models import InteractionContextRule, InteractionLog, InteractionWeightRule
+from apps.users.models import User
+
+
+def record_view_interaction(
+    *,
+    user: User,
+    game_id: int,
+    source: str,
+    metadata: dict[str, object] | list[object] | str | int | float | bool | None = None,
+) -> tuple[InteractionLog, bool]:
+    game = Game.objects.filter(id=game_id, is_visible=True).first()
+    if game is None:
+        raise CustomAPIException(ErrorMessages.GAME_NOT_FOUND)
+
+    weight_rule = InteractionWeightRule.objects.filter(
+        interaction_type=InteractionLog.ActionType.VIEW,
+        is_active=True,
+    ).first()
+    if weight_rule is None:
+        raise CustomAPIException(ErrorMessages.INTERACTION_TYPE_NOT_FOUND)
+
+    context_rule = InteractionContextRule.objects.filter(
+        interaction_source=source,
+    ).first()
+    if context_rule is None:
+        raise CustomAPIException(ErrorMessages.SOURCE_NOT_FOUND)
+
+    latest_reusable_log = (
+        InteractionLog.objects.filter(
+            user=user,
+            game=game,
+            type=InteractionLog.ActionType.VIEW,
+            weight__isnull=False,
+        )
+        .order_by("-created_at")
+        .first()
+    )
+    if (
+        latest_reusable_log is not None
+        and weight_rule.cooldown_seconds > 0
+        and latest_reusable_log.created_at >= timezone.now() - timedelta(seconds=weight_rule.cooldown_seconds)
+    ):
+        return latest_reusable_log, False
+
+    repeat_count = InteractionLog.objects.filter(
+        user=user,
+        game=game,
+        type=InteractionLog.ActionType.VIEW,
+    ).count()
+    weight: Decimal = (
+        weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**repeat_count)
+    ).quantize(Decimal("0.0001"))
+
+    log = InteractionLog.objects.create(
+        user=user,
+        game=game,
+        type=InteractionLog.ActionType.VIEW,
+        source=source,
+        weight=weight,
+        metadata=metadata,
+    )
+    return log, True

--- a/apps/interactions/services/view_log_service.py
+++ b/apps/interactions/services/view_log_service.py
@@ -4,6 +4,7 @@ import json
 from datetime import timedelta
 from decimal import Decimal
 
+from django.db import transaction
 from django.utils import timezone
 
 from apps.core.exceptions.exception_handler import CustomAPIException
@@ -26,60 +27,61 @@ def record_view_interaction(
         except (TypeError, ValueError):
             raise CustomAPIException(ErrorMessages.VALIDATION_ERROR) from None
 
-    try:
-        game = Game.objects.get(id=game_id, is_visible=True)
-    except Game.DoesNotExist:
+    game = Game.objects.filter(id=game_id, is_visible=True).first()
+    if game is None:
         raise CustomAPIException(ErrorMessages.GAME_NOT_FOUND) from None
 
-    try:
-        weight_rule = InteractionWeightRule.objects.get(
-            interaction_type=InteractionLog.ActionType.VIEW,
-            is_active=True,
-        )
-    except InteractionWeightRule.DoesNotExist:
+    weight_rule = InteractionWeightRule.objects.filter(
+        interaction_type=InteractionLog.ActionType.VIEW,
+        is_active=True,
+    ).first()
+    if weight_rule is None:
         raise CustomAPIException(ErrorMessages.INTERACTION_TYPE_NOT_FOUND) from None
 
-    try:
-        context_rule = InteractionContextRule.objects.get(interaction_source=source)
-    except InteractionContextRule.DoesNotExist:
+    context_rule = InteractionContextRule.objects.filter(interaction_source=source).first()
+    if context_rule is None:
         raise CustomAPIException(ErrorMessages.SOURCE_NOT_FOUND) from None
 
-    latest_reusable_log = (
-        InteractionLog.objects.filter(
+    with transaction.atomic():
+        # 동일 사용자 요청을 직렬화해 cooldown 체크-생성 사이 경쟁 조건을 줄인다.
+        User.objects.select_for_update().get(pk=user.pk)
+
+        latest_reusable_log = (
+            InteractionLog.objects.filter(
+                user=user,
+                game=game,
+                type=InteractionLog.ActionType.VIEW,
+                source=source,
+                weight__isnull=False,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if (
+            latest_reusable_log is not None
+            and weight_rule.cooldown_seconds > 0
+            and latest_reusable_log.created_at >= timezone.now() - timedelta(seconds=weight_rule.cooldown_seconds)
+        ):
+            return latest_reusable_log, False
+
+        repeat_count = InteractionLog.objects.filter(
+            user=user,
+            game=game,
+            type=InteractionLog.ActionType.VIEW,
+        ).count()
+        effective_repeat_count = min(repeat_count, 10)
+        weight: Decimal = (
+            weight_rule.base_weight
+            * context_rule.multiplier
+            * (weight_rule.repeat_decay**effective_repeat_count)
+        ).quantize(Decimal("0.0001"))
+
+        log = InteractionLog.objects.create(
             user=user,
             game=game,
             type=InteractionLog.ActionType.VIEW,
             source=source,
-            weight__isnull=False,
+            weight=weight,
+            metadata=metadata,
         )
-        .order_by("-created_at")
-        .first()
-    )
-    if (
-        latest_reusable_log is not None
-        and weight_rule.cooldown_seconds > 0
-        and latest_reusable_log.created_at >= timezone.now() - timedelta(seconds=weight_rule.cooldown_seconds)
-    ):
-        return latest_reusable_log, False
-
-    repeat_count = InteractionLog.objects.filter(
-        user=user,
-        game=game,
-        type=InteractionLog.ActionType.VIEW,
-    ).count()
-    effective_repeat_count = min(repeat_count, 10)
-    weight: Decimal = (
-        weight_rule.base_weight
-        * context_rule.multiplier
-        * (weight_rule.repeat_decay**effective_repeat_count)
-    ).quantize(Decimal("0.0001"))
-
-    log = InteractionLog.objects.create(
-        user=user,
-        game=game,
-        type=InteractionLog.ActionType.VIEW,
-        source=source,
-        weight=weight,
-        metadata=metadata,
-    )
-    return log, True
+        return log, True

--- a/apps/interactions/services/view_log_service.py
+++ b/apps/interactions/services/view_log_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import timedelta
 from decimal import Decimal
 
@@ -19,6 +20,12 @@ def record_view_interaction(
     source: str,
     metadata: dict[str, object] | list[object] | str | int | float | bool | None = None,
 ) -> tuple[InteractionLog, bool]:
+    if metadata is not None:
+        try:
+            json.dumps(metadata)
+        except (TypeError, ValueError):
+            raise CustomAPIException(ErrorMessages.VALIDATION_ERROR) from None
+
     try:
         game = Game.objects.get(id=game_id, is_visible=True)
     except Game.DoesNotExist:
@@ -42,6 +49,7 @@ def record_view_interaction(
             user=user,
             game=game,
             type=InteractionLog.ActionType.VIEW,
+            source=source,
             weight__isnull=False,
         )
         .order_by("-created_at")
@@ -59,8 +67,11 @@ def record_view_interaction(
         game=game,
         type=InteractionLog.ActionType.VIEW,
     ).count()
+    effective_repeat_count = min(repeat_count, 10)
     weight: Decimal = (
-        weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**repeat_count)
+        weight_rule.base_weight
+        * context_rule.multiplier
+        * (weight_rule.repeat_decay**effective_repeat_count)
     ).quantize(Decimal("0.0001"))
 
     log = InteractionLog.objects.create(

--- a/apps/interactions/tests.py
+++ b/apps/interactions/tests.py
@@ -165,6 +165,26 @@ class InteractionViewLogCreateAPITestCase(TestCase):
         self.assertIn("logged_at", data)
         self.assertEqual(InteractionLog.objects.count(), 1)
 
+    def test_interaction_view_different_source_is_logged_even_in_cooldown(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 201)
+        self.assertEqual(InteractionLog.objects.count(), 2)
+
     def test_interaction_view_recent_null_weight_log_is_not_reused_for_cooldown(self) -> None:
         user = self._create_user()
         game = self._create_game()

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -24,7 +24,7 @@ from apps.users.models import User
     description=(
         "게임 조회(view) 행동을 기록합니다.\n\n"
         "- 최초 기록 시: `201`\n"
-        "- 쿨다운 내 중복 요청 시: 로그를 추가 생성하지 않고 `200`으로 기존 최근 로그를 반환합니다.\n"
+        "- 동일 source에서 쿨다운 내 중복 요청 시: 로그를 추가 생성하지 않고 `200`으로 기존 최근 로그를 반환합니다.\n"
         "- 가중치는 `interaction_weight_rules`(type=view)와 "
         "`interaction_context_rules`(source) 조합으로 계산됩니다."
     ),

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -1,25 +1,20 @@
 from __future__ import annotations
 
-from datetime import timedelta
-from decimal import Decimal
 from typing import cast
 
-from django.utils import timezone
 from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
 from apps.core.serializers.error_serializer import ErrorResponseSerializer
-from apps.games.models import Game
-from apps.interactions.models import InteractionContextRule, InteractionLog, InteractionWeightRule
 from apps.interactions.serializers import (
     InteractionViewLogRequestSerializer,
     InteractionViewLogResponseSerializer,
 )
+from apps.interactions.services import record_view_interaction
 from apps.users.models import User
 
 
@@ -28,7 +23,7 @@ from apps.users.models import User
     summary="게임 조회 행동 기록",
     description=(
         "게임 조회(view) 행동을 기록합니다.\n\n"
-        "- 최초 기록 시: `201` + `logged=true`\n"
+        "- 최초 기록 시: `201`\n"
         "- 쿨다운 내 중복 요청 시: 로그를 추가 생성하지 않고 `200`으로 기존 최근 로그를 반환합니다.\n"
         "- 가중치는 `interaction_weight_rules`(type=view)와 "
         "`interaction_context_rules`(source) 조합으로 계산됩니다."
@@ -144,59 +139,13 @@ class InteractionViewLogCreateView(APIView):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
-        game = Game.objects.filter(id=data["game_id"], is_visible=True).first()
-        if game is None:
-            raise CustomAPIException(ErrorMessages.GAME_NOT_FOUND)
-
-        weight_rule = InteractionWeightRule.objects.filter(
-            interaction_type=InteractionLog.ActionType.VIEW,
-            is_active=True,
-        ).first()
-        if weight_rule is None:
-            raise CustomAPIException(ErrorMessages.INTERACTION_TYPE_NOT_FOUND)
-
-        context_rule = InteractionContextRule.objects.filter(
-            interaction_source=data["source"],
-        ).first()
-        if context_rule is None:
-            raise CustomAPIException(ErrorMessages.SOURCE_NOT_FOUND)
-
         user = cast(User, request.user)
-        latest_reusable_log = (
-            InteractionLog.objects.filter(
-                user=user,
-                game=game,
-                type=InteractionLog.ActionType.VIEW,
-                weight__isnull=False,
-            )
-            .order_by("-created_at")
-            .first()
-        )
-        if (
-            latest_reusable_log is not None
-            and weight_rule.cooldown_seconds > 0
-            and latest_reusable_log.created_at >= timezone.now() - timedelta(seconds=weight_rule.cooldown_seconds)
-        ):
-            response_serializer = InteractionViewLogResponseSerializer(latest_reusable_log)
-            return Response(response_serializer.data, status=200)
-
-        repeat_count = InteractionLog.objects.filter(
+        log, created = record_view_interaction(
             user=user,
-            game=game,
-            type=InteractionLog.ActionType.VIEW,
-        ).count()
-        weight: Decimal = (
-            weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**repeat_count)
-        ).quantize(Decimal("0.0001"))
-
-        log = InteractionLog.objects.create(
-            user=user,
-            game=game,
-            type=InteractionLog.ActionType.VIEW,
+            game_id=data["game_id"],
             source=data["source"],
-            weight=weight,
             metadata=data.get("metadata"),
         )
 
         response_serializer = InteractionViewLogResponseSerializer(log)
-        return Response(response_serializer.data, status=201)
+        return Response(response_serializer.data, status=201 if created else 200)


### PR DESCRIPTION
## ✅ PR 요약
- interactions/view 비즈니스 로직 service 분리

## 📄 상세 내용
- [x] apps/interactions/services/view_log_service.py (게임 조회/노출 체크,쿨다운 재사용 판정, repeat_count 계산 + weight 계산 ,로그 생성/재사용 반환 ,반환: (InteractionLog, created: bool))
- [x]  apps/interactions/services/__init__.py  (record_view_interaction export)

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] 빌드/린트가 통과합니다. (가능한 경우)

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
