### PR TITLE
[Feature/interactions search] 검색 행동 기록 API 추가

### DIFF
--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -30,3 +30,28 @@ class InteractionViewLogResponseSerializer(serializers.Serializer):  # type: ign
     id = serializers.IntegerField()
     type = serializers.CharField()
     logged_at = serializers.DateTimeField(source="created_at")
+
+
+class InteractionSearchLogRequestSerializer(serializers.Serializer[dict[str, Any]]):
+    game_id = serializers.IntegerField(min_value=1, required=False)
+    search_query = serializers.CharField(required=False)
+    source = serializers.CharField(required=False)  # type: ignore[assignment]
+    metadata = serializers.JSONField(required=False)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if attrs.get("search_query") is None:
+            raise CustomAPIException(ErrorMessages.SEARCH_QUERY_MISSING)
+        if attrs.get("game_id") is None or attrs.get("source") is None:
+            raise CustomAPIException(ErrorMessages.GAME_ID_OR_SOURCE_MISSING)
+        return attrs
+
+    def validate_source(self, value: str) -> str:
+        if value != InteractionLog.SourceType.SEARCH_RESULT:
+            raise CustomAPIException(ErrorMessages.INVALID_SOURCE)
+        return value
+
+
+class InteractionSearchLogResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    id = serializers.IntegerField()
+    type = serializers.CharField()
+    created_at = serializers.DateTimeField()

--- a/apps/interactions/services/__init__.py
+++ b/apps/interactions/services/__init__.py
@@ -1,3 +1,3 @@
-from .view_log_service import record_view_interaction
+from .view_log_service import record_search_interaction, record_view_interaction
 
-__all__ = ["record_view_interaction"]
+__all__ = ["record_view_interaction", "record_search_interaction"]

--- a/apps/interactions/services/view_log_service.py
+++ b/apps/interactions/services/view_log_service.py
@@ -83,3 +83,77 @@ def record_view_interaction(
             metadata=metadata,
         )
         return log, True
+
+
+def record_search_interaction(
+    *,
+    user: User,
+    game_id: int,
+    source: str,
+    search_query: str,
+    metadata: dict[str, object] | list[object] | str | int | float | bool | None = None,
+) -> tuple[InteractionLog, bool]:
+    if metadata is not None:
+        try:
+            json.dumps(metadata)
+        except (TypeError, ValueError):
+            raise CustomAPIException(ErrorMessages.VALIDATION_ERROR) from None
+
+    game = Game.objects.filter(id=game_id, is_visible=True).first()
+    if game is None:
+        raise CustomAPIException(ErrorMessages.GAME_NOT_FOUND) from None
+
+    weight_rule = InteractionWeightRule.objects.filter(
+        interaction_type=InteractionLog.ActionType.SEARCH,
+        is_active=True,
+    ).first()
+    if weight_rule is None:
+        raise CustomAPIException(ErrorMessages.INTERACTION_TYPE_NOT_FOUND) from None
+
+    context_rule = InteractionContextRule.objects.filter(interaction_source=source).first()
+    if context_rule is None:
+        raise CustomAPIException(ErrorMessages.SOURCE_NOT_FOUND) from None
+
+    with transaction.atomic():
+        # 동일 사용자 요청을 직렬화해 cooldown 체크-생성 사이 경쟁 조건을 줄인다.
+        User.objects.select_for_update().get(pk=user.pk)
+
+        latest_reusable_log = (
+            InteractionLog.objects.filter(
+                user=user,
+                game=game,
+                type=InteractionLog.ActionType.SEARCH,
+                source=source,
+                search_query=search_query,
+                weight__isnull=False,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if (
+            latest_reusable_log is not None
+            and weight_rule.cooldown_seconds > 0
+            and latest_reusable_log.created_at >= timezone.now() - timedelta(seconds=weight_rule.cooldown_seconds)
+        ):
+            return latest_reusable_log, False
+
+        repeat_count = InteractionLog.objects.filter(
+            user=user,
+            game=game,
+            type=InteractionLog.ActionType.SEARCH,
+        ).count()
+        effective_repeat_count = min(repeat_count, 10)
+        weight: Decimal = (
+            weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**effective_repeat_count)
+        ).quantize(Decimal("0.0001"))
+
+        log = InteractionLog.objects.create(
+            user=user,
+            game=game,
+            type=InteractionLog.ActionType.SEARCH,
+            source=source,
+            search_query=search_query,
+            weight=weight,
+            metadata=metadata,
+        )
+        return log, True

--- a/apps/interactions/tests.py
+++ b/apps/interactions/tests.py
@@ -268,3 +268,243 @@ class InteractionViewLogCreateAPITestCase(TestCase):
         second_log = InteractionLog.objects.get(id=second_id)
         self.assertIsNotNone(second_log.weight)
         self.assertEqual(float(cast(Any, second_log.weight)), 0.216)  # 0.2 * 1.2 * 0.9^1
+
+
+class InteractionSearchLogCreateAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/interactions/search/"
+        self._create_search_rules()
+
+    def _create_user(self) -> User:
+        return User.objects.create_user(
+            email="search-user@ex.com",
+            nickname="search-user",
+            birth_date=date(1992, 1, 1),
+            password="pw",
+        )
+
+    def _create_game(self, **kwargs: Any) -> Game:
+        defaults = {
+            "rawg_id": 7001,
+            "slug": "search-game",
+            "name": "Search Game",
+            "thumbnail_img_url": "https://example.com/search-thumb.jpg",
+            "website": "https://example.com/search",
+            "rawg_rating": 4.20,
+            "is_visible": True,
+        }
+        defaults.update(kwargs)
+        return Game.objects.create(**defaults)
+
+    def _create_search_rules(self) -> None:
+        InteractionWeightRule.objects.create(
+            interaction_type=InteractionWeightRule.ActionType.SEARCH,
+            base_weight=0.10,
+            cooldown_seconds=120,
+            repeat_decay=0.900,
+            is_active=True,
+        )
+        InteractionContextRule.objects.get_or_create(
+            interaction_source=InteractionContextRule.InteractionSource.SEARCH_RESULT,
+            defaults={"multiplier": 1.10},
+        )
+
+    def test_interaction_search_unauthorized(self) -> None:
+        response = self.client.post(
+            self.url,
+            {"game_id": 1, "search_query": "elden ring", "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_interaction_search_missing_search_query_returns_400(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "SEARCH_QUERY_MISSING")
+
+    def test_interaction_search_missing_game_id_or_source_returns_400(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"search_query": "elden ring", "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "GAME_ID_OR_SOURCE_MISSING")
+
+    def test_interaction_search_invalid_source_returns_400(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "search_query": "elden ring", "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "INVALID_SOURCE")
+
+    def test_interaction_search_game_not_found_returns_404(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": 999999, "search_query": "elden ring", "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "GAME_NOT_FOUND")
+
+    def test_interaction_search_success(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {
+                "game_id": game.id,
+                "search_query": "elden ring",
+                "source": "search_result",
+                "metadata": {"result_rank": 3},
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+
+        data = cast(dict[str, Any], response.data)
+        self.assertIn("id", data)
+        self.assertEqual(data["type"], "search")
+        self.assertIn("created_at", data)
+
+        log = InteractionLog.objects.get(id=data["id"])
+        self.assertEqual(log.user_id, user.id)
+        self.assertEqual(log.game_id, game.id)
+        self.assertEqual(log.type, InteractionLog.ActionType.SEARCH)
+        self.assertEqual(log.source, InteractionLog.SourceType.SEARCH_RESULT)
+        self.assertEqual(log.search_query, "elden ring")
+        self.assertIsNotNone(log.weight)
+        self.assertEqual(float(cast(Any, log.weight)), 0.11)
+
+    def test_interaction_search_cooldown_ignored_returns_200(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "search_query": "elden ring", "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(InteractionLog.objects.count(), 1)
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "search_query": "elden ring", "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(InteractionLog.objects.count(), 1)
+
+    def test_interaction_search_different_query_is_logged_even_in_cooldown(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "search_query": "elden ring", "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "search_query": "stardew valley", "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 201)
+        self.assertEqual(InteractionLog.objects.count(), 2)
+
+    def test_interaction_search_missing_weight_rule_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+        InteractionWeightRule.objects.filter(interaction_type=InteractionWeightRule.ActionType.SEARCH).delete()
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "search_query": "elden ring", "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "INTERACTION_TYPE_NOT_FOUND")
+
+    def test_interaction_search_missing_source_rule_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+        InteractionContextRule.objects.filter(
+            interaction_source=InteractionContextRule.InteractionSource.SEARCH_RESULT
+        ).delete()
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "search_query": "elden ring", "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "SOURCE_NOT_FOUND")
+
+    def test_interaction_search_repeat_decay_applied(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+        InteractionWeightRule.objects.filter(interaction_type=InteractionWeightRule.ActionType.SEARCH).update(
+            cooldown_seconds=0,
+            repeat_decay=0.900,
+        )
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "search_query": "elden ring", "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+        first_id = cast(dict[str, Any], first.data)["id"]
+        first_log = InteractionLog.objects.get(id=first_id)
+        self.assertIsNotNone(first_log.weight)
+        self.assertEqual(float(cast(Any, first_log.weight)), 0.11)  # 0.1 * 1.1 * 0.9^0
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "search_query": "elden ring", "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 201)
+        second_id = cast(dict[str, Any], second.data)["id"]
+        second_log = InteractionLog.objects.get(id=second_id)
+        self.assertIsNotNone(second_log.weight)
+        self.assertEqual(float(cast(Any, second_log.weight)), 0.099)  # 0.1 * 1.1 * 0.9^1

--- a/apps/interactions/urls.py
+++ b/apps/interactions/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from apps.interactions.views import InteractionViewLogCreateView
+from apps.interactions.views import InteractionSearchLogCreateView, InteractionViewLogCreateView
 
 urlpatterns = [
     path("view/", InteractionViewLogCreateView.as_view(), name="interaction-view-create"),
+    path("search/", InteractionSearchLogCreateView.as_view(), name="interaction-search-create"),
 ]

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -11,10 +11,12 @@ from rest_framework.views import APIView
 from apps.core.exceptions.exception_message import ErrorMessages
 from apps.core.serializers.error_serializer import ErrorResponseSerializer
 from apps.interactions.serializers import (
+    InteractionSearchLogRequestSerializer,
+    InteractionSearchLogResponseSerializer,
     InteractionViewLogRequestSerializer,
     InteractionViewLogResponseSerializer,
 )
-from apps.interactions.services import record_view_interaction
+from apps.interactions.services import record_search_interaction, record_view_interaction
 from apps.users.models import User
 
 
@@ -148,4 +150,148 @@ class InteractionViewLogCreateView(APIView):
         )
 
         response_serializer = InteractionViewLogResponseSerializer(log)
+        return Response(response_serializer.data, status=201 if created else 200)
+
+
+@extend_schema(
+    tags=["Interactions"],
+    summary="게임 검색 행동 기록",
+    description=(
+        "게임 검색(search) 행동을 기록합니다.\n\n"
+        "- 이 API는 **게임이 선택된 검색 행동만** 기록하므로 `game_id`가 필수입니다.\n"
+        "- 최초 기록 시: `201`\n"
+        "- 동일 검색어/동일 game/source에서 쿨다운 내 중복 요청 시: 로그를 추가 생성하지 않고 `200`으로 기존 최근 로그를 반환합니다.\n"
+        "- 가중치는 `interaction_weight_rules`(type=search)와 "
+        "`interaction_context_rules`(source=search_result) 조합으로 계산됩니다."
+    ),
+    request=InteractionSearchLogRequestSerializer,
+    examples=[
+        OpenApiExample(
+            "요청 예시",
+            value={
+                "game_id": 1,
+                "search_query": "elden ring",
+                "source": "search_result",
+                "metadata": {"result_rank": 2, "keyword_length": 10},
+            },
+            request_only=True,
+        ),
+        OpenApiExample(
+            "생성 응답 예시 (201)",
+            value={
+                "id": 201,
+                "type": "search",
+                "created_at": "2026-03-11T08:30:00Z",
+            },
+            response_only=True,
+            status_codes=["201"],
+        ),
+        OpenApiExample(
+            "쿨다운 무시 응답 예시 (200)",
+            value={
+                "id": 201,
+                "type": "search",
+                "created_at": "2026-03-11T08:30:00Z",
+            },
+            response_only=True,
+            status_codes=["200"],
+        ),
+    ],
+    responses={
+        200: InteractionSearchLogResponseSerializer,
+        201: InteractionSearchLogResponseSerializer,
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Bad Request",
+            examples=[
+                OpenApiExample(
+                    "search_query 누락",
+                    value={
+                        "status_code": ErrorMessages.SEARCH_QUERY_MISSING.status_code,
+                        "code": ErrorMessages.SEARCH_QUERY_MISSING.name,
+                        "message": ErrorMessages.SEARCH_QUERY_MISSING.message,
+                    },
+                ),
+                OpenApiExample(
+                    "game_id/source 누락",
+                    value={
+                        "status_code": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.status_code,
+                        "code": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.name,
+                        "message": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.message,
+                    },
+                ),
+                OpenApiExample(
+                    "source 값 오류",
+                    value={
+                        "status_code": ErrorMessages.INVALID_SOURCE.status_code,
+                        "code": ErrorMessages.INVALID_SOURCE.name,
+                        "message": ErrorMessages.INVALID_SOURCE.message,
+                    },
+                ),
+            ],
+        ),
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Unauthorized",
+            examples=[
+                OpenApiExample(
+                    "인증 필요",
+                    value={
+                        "status_code": ErrorMessages.UNAUTHORIZED.status_code,
+                        "code": ErrorMessages.UNAUTHORIZED.name,
+                        "message": ErrorMessages.UNAUTHORIZED.message,
+                    },
+                )
+            ],
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Not Found",
+            examples=[
+                OpenApiExample(
+                    "게임 없음",
+                    value={
+                        "status_code": ErrorMessages.GAME_NOT_FOUND.status_code,
+                        "code": ErrorMessages.GAME_NOT_FOUND.name,
+                        "message": ErrorMessages.GAME_NOT_FOUND.message,
+                    },
+                ),
+                OpenApiExample(
+                    "search 룰 없음",
+                    value={
+                        "status_code": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.status_code,
+                        "code": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.name,
+                        "message": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.message,
+                    },
+                ),
+                OpenApiExample(
+                    "source 룰 없음",
+                    value={
+                        "status_code": ErrorMessages.SOURCE_NOT_FOUND.status_code,
+                        "code": ErrorMessages.SOURCE_NOT_FOUND.name,
+                        "message": ErrorMessages.SOURCE_NOT_FOUND.message,
+                    },
+                ),
+            ],
+        ),
+    },
+)
+class InteractionSearchLogCreateView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request) -> Response:
+        serializer = InteractionSearchLogRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        user = cast(User, request.user)
+        log, created = record_search_interaction(
+            user=user,
+            game_id=data["game_id"],
+            search_query=data["search_query"],
+            source=data["source"],
+            metadata=data.get("metadata"),
+        )
+
+        response_serializer = InteractionSearchLogResponseSerializer(log)
         return Response(response_serializer.data, status=201 if created else 200)


### PR DESCRIPTION
## ✅ PR 요약
- POST /api/v1/interactions/search/ 행동 기록 API 추가

## 📄 상세 내용
- [x] 게임 선택된 검색만 기록 (`game_id` 필수)
- [x] View/URL/Serializer/Service 추가
- [x] cooldown(200) / 신규생성(201) 분기 처리
- [x] weight + repeat decay 로직 적용

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] InteractionSearchLogCreateAPITestCase` 11개 통과
- [x] 빌드/린트가 통과합니다. (가능한 경우)


## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
