### PR TITLE
[Refactor/interactions] 응답 필드 및 반복감쇠 정책 일관성 정리

### DIFF
--- a/apps/interactions/migrations/0003_interactionlog_store_and_index.py
+++ b/apps/interactions/migrations/0003_interactionlog_store_and_index.py
@@ -1,0 +1,27 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("games", "0003_alter_game_esrb_rating"),
+        ("interactions", "0002_remove_interactioncontextrule_created_at_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="interactionlog",
+            name="store",
+            field=models.ForeignKey(
+                blank=True,
+                db_column="store_id",
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="games.externalstore",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="interactionlog",
+            index=models.Index(fields=["store"], name="interaction_store_i_4e10f0_idx"),
+        ),
+    ]

--- a/apps/interactions/models/interaction_log.py
+++ b/apps/interactions/models/interaction_log.py
@@ -39,6 +39,14 @@ class InteractionLog(models.Model):
         blank=True,
     )
 
+    store = models.ForeignKey(
+        "games.ExternalStore",
+        on_delete=models.CASCADE,
+        db_column="store_id",
+        null=True,
+        blank=True,
+    )
+
     search_query = models.TextField(
         null=True,
         blank=True,
@@ -75,6 +83,7 @@ class InteractionLog(models.Model):
         indexes = [
             models.Index(fields=["user"]),
             models.Index(fields=["game"]),
+            models.Index(fields=["store"]),
             models.Index(fields=["type"]),
             models.Index(fields=["created_at"]),
         ]

--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -10,6 +10,7 @@ from apps.interactions.models import InteractionLog
 
 
 class InteractionViewLogRequestSerializer(serializers.Serializer[dict[str, Any]]):
+    # 커스텀 통합 에러코드(GAME_ID_OR_SOURCE_MISSING)를 유지하기 위해 required=False 후 validate에서 검사한다.
     game_id = serializers.IntegerField(min_value=1, required=False)
     source = serializers.CharField(required=False)  # type: ignore[assignment]
     metadata = serializers.JSONField(required=False)
@@ -33,6 +34,7 @@ class InteractionViewLogResponseSerializer(serializers.Serializer):  # type: ign
 
 
 class InteractionSearchLogRequestSerializer(serializers.Serializer[dict[str, Any]]):
+    # 커스텀 통합/도메인 에러코드 유지를 위해 required=False 후 validate에서 검사한다.
     game_id = serializers.IntegerField(min_value=1, required=False)
     search_query = serializers.CharField(required=False)
     source = serializers.CharField(required=False)  # type: ignore[assignment]
@@ -54,10 +56,11 @@ class InteractionSearchLogRequestSerializer(serializers.Serializer[dict[str, Any
 class InteractionSearchLogResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
     id = serializers.IntegerField()
     type = serializers.CharField()
-    created_at = serializers.DateTimeField()
+    logged_at = serializers.DateTimeField(source="created_at")
 
 
 class InteractionStoreClickLogRequestSerializer(serializers.Serializer[dict[str, Any]]):
+    # 커스텀 통합 에러코드 유지를 위해 required=False 후 validate에서 검사한다.
     game_id = serializers.IntegerField(min_value=1, required=False)
     store_id = serializers.IntegerField(min_value=1, required=False)
     source = serializers.CharField(required=False)  # type: ignore[assignment]
@@ -79,4 +82,4 @@ class InteractionStoreClickLogRequestSerializer(serializers.Serializer[dict[str,
 class InteractionStoreClickLogResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
     id = serializers.IntegerField()
     type = serializers.CharField()
-    routed_at = serializers.DateTimeField(source="created_at")
+    logged_at = serializers.DateTimeField(source="created_at")

--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -55,3 +55,28 @@ class InteractionSearchLogResponseSerializer(serializers.Serializer):  # type: i
     id = serializers.IntegerField()
     type = serializers.CharField()
     created_at = serializers.DateTimeField()
+
+
+class InteractionStoreClickLogRequestSerializer(serializers.Serializer[dict[str, Any]]):
+    game_id = serializers.IntegerField(min_value=1, required=False)
+    store_id = serializers.IntegerField(min_value=1, required=False)
+    source = serializers.CharField(required=False)  # type: ignore[assignment]
+    metadata = serializers.JSONField(required=False)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if attrs.get("game_id") is None or attrs.get("store_id") is None:
+            raise CustomAPIException(ErrorMessages.GAME_ID_OR_STORE_ID_MISSING)
+        if attrs.get("source") is None:
+            raise CustomAPIException(ErrorMessages.GAME_ID_OR_SOURCE_MISSING)
+        return attrs
+
+    def validate_source(self, value: str) -> str:
+        if value != InteractionLog.SourceType.DETAIL_PAGE:
+            raise CustomAPIException(ErrorMessages.INVALID_SOURCE)
+        return value
+
+
+class InteractionStoreClickLogResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    id = serializers.IntegerField()
+    type = serializers.CharField()
+    routed_at = serializers.DateTimeField(source="created_at")

--- a/apps/interactions/services/__init__.py
+++ b/apps/interactions/services/__init__.py
@@ -1,3 +1,7 @@
-from .view_log_service import record_search_interaction, record_view_interaction
+from .view_log_service import (
+    record_search_interaction,
+    record_store_click_interaction,
+    record_view_interaction,
+)
 
-__all__ = ["record_view_interaction", "record_search_interaction"]
+__all__ = ["record_view_interaction", "record_search_interaction", "record_store_click_interaction"]

--- a/apps/interactions/services/view_log_service.py
+++ b/apps/interactions/services/view_log_service.py
@@ -13,6 +13,9 @@ from apps.games.models import ExternalStore, Game, GameStore
 from apps.interactions.models import InteractionContextRule, InteractionLog, InteractionWeightRule
 from apps.users.models import User
 
+MAX_EFFECTIVE_REPEAT_COUNT = 10
+WEIGHT_QUANTIZE_UNIT = Decimal("0.0001")
+
 
 def record_view_interaction(
     *,
@@ -69,10 +72,10 @@ def record_view_interaction(
             game=game,
             type=InteractionLog.ActionType.VIEW,
         ).count()
-        effective_repeat_count = min(repeat_count, 10)
+        effective_repeat_count = min(repeat_count, MAX_EFFECTIVE_REPEAT_COUNT)
         weight: Decimal = (
             weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**effective_repeat_count)
-        ).quantize(Decimal("0.0001"))
+        ).quantize(WEIGHT_QUANTIZE_UNIT)
 
         log = InteractionLog.objects.create(
             user=user,
@@ -142,10 +145,10 @@ def record_search_interaction(
             game=game,
             type=InteractionLog.ActionType.SEARCH,
         ).count()
-        effective_repeat_count = min(repeat_count, 10)
+        effective_repeat_count = min(repeat_count, MAX_EFFECTIVE_REPEAT_COUNT)
         weight: Decimal = (
             weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**effective_repeat_count)
-        ).quantize(Decimal("0.0001"))
+        ).quantize(WEIGHT_QUANTIZE_UNIT)
 
         log = InteractionLog.objects.create(
             user=user,
@@ -223,10 +226,10 @@ def record_store_click_interaction(
             store=store,
             type=InteractionLog.ActionType.STORE_CLICK,
         ).count()
-        effective_repeat_count = min(repeat_count, 10)
+        effective_repeat_count = min(repeat_count, MAX_EFFECTIVE_REPEAT_COUNT)
         weight: Decimal = (
             weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**effective_repeat_count)
-        ).quantize(Decimal("0.0001"))
+        ).quantize(WEIGHT_QUANTIZE_UNIT)
 
         log = InteractionLog.objects.create(
             user=user,

--- a/apps/interactions/services/view_log_service.py
+++ b/apps/interactions/services/view_log_service.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
-from apps.games.models import Game
+from apps.games.models import ExternalStore, Game, GameStore
 from apps.interactions.models import InteractionContextRule, InteractionLog, InteractionWeightRule
 from apps.users.models import User
 
@@ -153,6 +153,87 @@ def record_search_interaction(
             type=InteractionLog.ActionType.SEARCH,
             source=source,
             search_query=search_query,
+            weight=weight,
+            metadata=metadata,
+        )
+        return log, True
+
+
+def record_store_click_interaction(
+    *,
+    user: User,
+    game_id: int,
+    store_id: int,
+    source: str,
+    metadata: dict[str, object] | list[object] | str | int | float | bool | None = None,
+) -> tuple[InteractionLog, bool]:
+    if metadata is not None:
+        try:
+            json.dumps(metadata)
+        except (TypeError, ValueError):
+            raise CustomAPIException(ErrorMessages.VALIDATION_ERROR) from None
+
+    game = Game.objects.filter(id=game_id, is_visible=True).first()
+    if game is None:
+        raise CustomAPIException(ErrorMessages.GAME_NOT_FOUND) from None
+
+    store = ExternalStore.objects.filter(id=store_id).first()
+    if store is None:
+        raise CustomAPIException(ErrorMessages.STORE_NOT_FOUND) from None
+    if not GameStore.objects.filter(game=game, store=store).exists():
+        raise CustomAPIException(ErrorMessages.STORE_NOT_FOUND) from None
+
+    weight_rule = InteractionWeightRule.objects.filter(
+        interaction_type=InteractionLog.ActionType.STORE_CLICK,
+        is_active=True,
+    ).first()
+    if weight_rule is None:
+        raise CustomAPIException(ErrorMessages.INTERACTION_TYPE_NOT_FOUND) from None
+
+    context_rule = InteractionContextRule.objects.filter(interaction_source=source).first()
+    if context_rule is None:
+        raise CustomAPIException(ErrorMessages.SOURCE_NOT_FOUND) from None
+
+    with transaction.atomic():
+        # 동일 사용자 요청을 직렬화해 cooldown 체크-생성 사이 경쟁 조건을 줄인다.
+        User.objects.select_for_update().get(pk=user.pk)
+
+        latest_reusable_log = (
+            InteractionLog.objects.filter(
+                user=user,
+                game=game,
+                store=store,
+                type=InteractionLog.ActionType.STORE_CLICK,
+                source=source,
+                weight__isnull=False,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if (
+            latest_reusable_log is not None
+            and weight_rule.cooldown_seconds > 0
+            and latest_reusable_log.created_at >= timezone.now() - timedelta(seconds=weight_rule.cooldown_seconds)
+        ):
+            return latest_reusable_log, False
+
+        repeat_count = InteractionLog.objects.filter(
+            user=user,
+            game=game,
+            store=store,
+            type=InteractionLog.ActionType.STORE_CLICK,
+        ).count()
+        effective_repeat_count = min(repeat_count, 10)
+        weight: Decimal = (
+            weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**effective_repeat_count)
+        ).quantize(Decimal("0.0001"))
+
+        log = InteractionLog.objects.create(
+            user=user,
+            game=game,
+            store=store,
+            type=InteractionLog.ActionType.STORE_CLICK,
+            source=source,
             weight=weight,
             metadata=metadata,
         )

--- a/apps/interactions/tests.py
+++ b/apps/interactions/tests.py
@@ -394,7 +394,7 @@ class InteractionSearchLogCreateAPITestCase(TestCase):
         data = cast(dict[str, Any], response.data)
         self.assertIn("id", data)
         self.assertEqual(data["type"], "search")
-        self.assertIn("created_at", data)
+        self.assertIn("logged_at", data)
 
         log = InteractionLog.objects.get(id=data["id"])
         self.assertEqual(log.user_id, user.id)
@@ -683,7 +683,7 @@ class InteractionStoreClickLogCreateAPITestCase(TestCase):
         data = cast(dict[str, Any], response.data)
         self.assertIn("id", data)
         self.assertEqual(data["type"], "store_click")
-        self.assertIn("routed_at", data)
+        self.assertIn("logged_at", data)
 
         log = InteractionLog.objects.get(id=data["id"])
         self.assertEqual(log.user_id, user.id)

--- a/apps/interactions/tests.py
+++ b/apps/interactions/tests.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from django.utils import timezone
 from rest_framework.test import APIClient
 
-from apps.games.models import Game
+from apps.games.models import ExternalStore, Game, GameStore
 from apps.interactions.models import InteractionContextRule, InteractionLog, InteractionWeightRule
 from apps.users.models import User
 
@@ -508,3 +508,304 @@ class InteractionSearchLogCreateAPITestCase(TestCase):
         second_log = InteractionLog.objects.get(id=second_id)
         self.assertIsNotNone(second_log.weight)
         self.assertEqual(float(cast(Any, second_log.weight)), 0.099)  # 0.1 * 1.1 * 0.9^1
+
+
+class InteractionStoreClickLogCreateAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/interactions/store-click/"
+        self._create_store_click_rules()
+
+    def _create_user(self) -> User:
+        return User.objects.create_user(
+            email="store-user@ex.com",
+            nickname="store-user",
+            birth_date=date(1993, 1, 1),
+            password="pw",
+        )
+
+    def _create_game(self, **kwargs: Any) -> Game:
+        defaults = {
+            "rawg_id": 8001,
+            "slug": "store-click-game",
+            "name": "Store Click Game",
+            "thumbnail_img_url": "https://example.com/store-thumb.jpg",
+            "website": "https://example.com/store-game",
+            "rawg_rating": 4.10,
+            "is_visible": True,
+        }
+        defaults.update(kwargs)
+        return Game.objects.create(**defaults)
+
+    def _create_store(self, **kwargs: Any) -> ExternalStore:
+        defaults = {
+            "rawg_id": 1001,
+            "name": "Steam",
+            "slug": "steam",
+            "domain": "store.steampowered.com",
+            "icon_url": "https://example.com/store-icon.png",
+        }
+        defaults.update(kwargs)
+        return ExternalStore.objects.create(**defaults)
+
+    def _create_game_store(self, game: Game, store: ExternalStore, **kwargs: Any) -> GameStore:
+        defaults = {"url": "https://store.steampowered.com/app/123"}
+        defaults.update(kwargs)
+        return GameStore.objects.create(game=game, store=store, **defaults)
+
+    def _create_store_click_rules(self) -> None:
+        InteractionWeightRule.objects.create(
+            interaction_type=InteractionWeightRule.ActionType.STORE_CLICK,
+            base_weight=0.10,
+            cooldown_seconds=120,
+            repeat_decay=0.900,
+            is_active=True,
+        )
+        InteractionContextRule.objects.get_or_create(
+            interaction_source=InteractionContextRule.InteractionSource.DETAIL_PAGE,
+            defaults={"multiplier": 1.20},
+        )
+
+    def test_interaction_store_click_unauthorized(self) -> None:
+        response = self.client.post(
+            self.url,
+            {"game_id": 1, "store_id": 1, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_interaction_store_click_missing_required_returns_400(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": 1, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "GAME_ID_OR_STORE_ID_MISSING")
+
+    def test_interaction_store_click_missing_source_returns_400(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": 1, "store_id": 1},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "GAME_ID_OR_SOURCE_MISSING")
+
+    def test_interaction_store_click_invalid_source_returns_400(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "INVALID_SOURCE")
+
+    def test_interaction_store_click_game_not_found_returns_404(self) -> None:
+        user = self._create_user()
+        store = self._create_store()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": 999999, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "GAME_NOT_FOUND")
+
+    def test_interaction_store_click_store_not_found_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": 999999, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "STORE_NOT_FOUND")
+
+    def test_interaction_store_click_unlinked_store_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "STORE_NOT_FOUND")
+
+    def test_interaction_store_click_success(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {
+                "game_id": game.id,
+                "store_id": store.id,
+                "source": "detail_page",
+                "metadata": {"button_position": "hero"},
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+
+        data = cast(dict[str, Any], response.data)
+        self.assertIn("id", data)
+        self.assertEqual(data["type"], "store_click")
+        self.assertIn("routed_at", data)
+
+        log = InteractionLog.objects.get(id=data["id"])
+        self.assertEqual(log.user_id, user.id)
+        self.assertEqual(log.game_id, game.id)
+        self.assertEqual(log.store_id, store.id)
+        self.assertEqual(log.type, InteractionLog.ActionType.STORE_CLICK)
+        self.assertEqual(log.source, InteractionLog.SourceType.DETAIL_PAGE)
+        self.assertIsNotNone(log.weight)
+        self.assertEqual(float(cast(Any, log.weight)), 0.12)
+
+    def test_interaction_store_click_cooldown_ignored_returns_200(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(InteractionLog.objects.count(), 1)
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(InteractionLog.objects.count(), 1)
+
+    def test_interaction_store_click_different_store_is_logged_even_in_cooldown(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store_a = self._create_store(rawg_id=1001, slug="steam", name="Steam")
+        store_b = self._create_store(rawg_id=1002, slug="gog", name="GOG", domain="gog.com")
+        self._create_game_store(game=game, store=store_a)
+        self._create_game_store(game=game, store=store_b, url="https://gog.com/game/123")
+        self.client.force_authenticate(user=user)
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store_a.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store_b.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 201)
+        self.assertEqual(InteractionLog.objects.count(), 2)
+
+    def test_interaction_store_click_missing_weight_rule_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+        InteractionWeightRule.objects.filter(interaction_type=InteractionWeightRule.ActionType.STORE_CLICK).delete()
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "INTERACTION_TYPE_NOT_FOUND")
+
+    def test_interaction_store_click_missing_source_rule_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+        InteractionContextRule.objects.filter(
+            interaction_source=InteractionContextRule.InteractionSource.DETAIL_PAGE
+        ).delete()
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "SOURCE_NOT_FOUND")
+
+    def test_interaction_store_click_repeat_decay_applied_per_store(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+        InteractionWeightRule.objects.filter(interaction_type=InteractionWeightRule.ActionType.STORE_CLICK).update(
+            cooldown_seconds=0,
+            repeat_decay=0.900,
+        )
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+        first_id = cast(dict[str, Any], first.data)["id"]
+        first_log = InteractionLog.objects.get(id=first_id)
+        self.assertIsNotNone(first_log.weight)
+        self.assertEqual(float(cast(Any, first_log.weight)), 0.12)  # 0.1 * 1.2 * 0.9^0
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 201)
+        second_id = cast(dict[str, Any], second.data)["id"]
+        second_log = InteractionLog.objects.get(id=second_id)
+        self.assertIsNotNone(second_log.weight)
+        self.assertEqual(float(cast(Any, second_log.weight)), 0.108)  # 0.1 * 1.2 * 0.9^1

--- a/apps/interactions/urls.py
+++ b/apps/interactions/urls.py
@@ -1,8 +1,13 @@
 from django.urls import path
 
-from apps.interactions.views import InteractionSearchLogCreateView, InteractionViewLogCreateView
+from apps.interactions.views import (
+    InteractionSearchLogCreateView,
+    InteractionStoreClickLogCreateView,
+    InteractionViewLogCreateView,
+)
 
 urlpatterns = [
     path("view/", InteractionViewLogCreateView.as_view(), name="interaction-view-create"),
     path("search/", InteractionSearchLogCreateView.as_view(), name="interaction-search-create"),
+    path("store-click/", InteractionStoreClickLogCreateView.as_view(), name="interaction-store-click-create"),
 ]

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -13,10 +13,16 @@ from apps.core.serializers.error_serializer import ErrorResponseSerializer
 from apps.interactions.serializers import (
     InteractionSearchLogRequestSerializer,
     InteractionSearchLogResponseSerializer,
+    InteractionStoreClickLogRequestSerializer,
+    InteractionStoreClickLogResponseSerializer,
     InteractionViewLogRequestSerializer,
     InteractionViewLogResponseSerializer,
 )
-from apps.interactions.services import record_search_interaction, record_view_interaction
+from apps.interactions.services import (
+    record_search_interaction,
+    record_store_click_interaction,
+    record_view_interaction,
+)
 from apps.users.models import User
 
 
@@ -294,4 +300,157 @@ class InteractionSearchLogCreateView(APIView):
         )
 
         response_serializer = InteractionSearchLogResponseSerializer(log)
+        return Response(response_serializer.data, status=201 if created else 200)
+
+
+@extend_schema(
+    tags=["Interactions"],
+    summary="외부 스토어 이동 행동 기록",
+    description=(
+        "게임 상세 페이지에서 외부 스토어 이동(store_click) 행동을 기록합니다.\n\n"
+        "- 이 API는 `source=detail_page`만 허용합니다.\n"
+        "- 최초 기록 시: `201`\n"
+        "- 동일 game/store/source에서 쿨다운 내 중복 요청 시: 로그를 추가 생성하지 않고 `200`으로 기존 최근 로그를 반환합니다.\n"
+        "- 반복 감쇠(repeat_decay) 계산은 `user + game + store + type` 기준으로 적용됩니다.\n"
+        "- 가중치는 `interaction_weight_rules`(type=store_click)와 "
+        "`interaction_context_rules`(source=detail_page) 조합으로 계산됩니다."
+    ),
+    request=InteractionStoreClickLogRequestSerializer,
+    examples=[
+        OpenApiExample(
+            "요청 예시",
+            value={
+                "game_id": 1,
+                "store_id": 3,
+                "source": "detail_page",
+                "metadata": {"button_position": "hero", "cta_variant": "primary"},
+            },
+            request_only=True,
+        ),
+        OpenApiExample(
+            "생성 응답 예시 (201)",
+            value={
+                "id": 301,
+                "type": "store_click",
+                "routed_at": "2026-03-11T08:30:00Z",
+            },
+            response_only=True,
+            status_codes=["201"],
+        ),
+        OpenApiExample(
+            "쿨다운 무시 응답 예시 (200)",
+            value={
+                "id": 301,
+                "type": "store_click",
+                "routed_at": "2026-03-11T08:30:00Z",
+            },
+            response_only=True,
+            status_codes=["200"],
+        ),
+    ],
+    responses={
+        200: InteractionStoreClickLogResponseSerializer,
+        201: InteractionStoreClickLogResponseSerializer,
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Bad Request",
+            examples=[
+                OpenApiExample(
+                    "game_id/store_id 누락",
+                    value={
+                        "status_code": ErrorMessages.GAME_ID_OR_STORE_ID_MISSING.status_code,
+                        "code": ErrorMessages.GAME_ID_OR_STORE_ID_MISSING.name,
+                        "message": ErrorMessages.GAME_ID_OR_STORE_ID_MISSING.message,
+                    },
+                ),
+                OpenApiExample(
+                    "source 누락",
+                    value={
+                        "status_code": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.status_code,
+                        "code": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.name,
+                        "message": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.message,
+                    },
+                ),
+                OpenApiExample(
+                    "source 값 오류",
+                    value={
+                        "status_code": ErrorMessages.INVALID_SOURCE.status_code,
+                        "code": ErrorMessages.INVALID_SOURCE.name,
+                        "message": ErrorMessages.INVALID_SOURCE.message,
+                    },
+                ),
+            ],
+        ),
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Unauthorized",
+            examples=[
+                OpenApiExample(
+                    "인증 필요",
+                    value={
+                        "status_code": ErrorMessages.UNAUTHORIZED.status_code,
+                        "code": ErrorMessages.UNAUTHORIZED.name,
+                        "message": ErrorMessages.UNAUTHORIZED.message,
+                    },
+                )
+            ],
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Not Found",
+            examples=[
+                OpenApiExample(
+                    "게임 없음",
+                    value={
+                        "status_code": ErrorMessages.GAME_NOT_FOUND.status_code,
+                        "code": ErrorMessages.GAME_NOT_FOUND.name,
+                        "message": ErrorMessages.GAME_NOT_FOUND.message,
+                    },
+                ),
+                OpenApiExample(
+                    "스토어 없음",
+                    value={
+                        "status_code": ErrorMessages.STORE_NOT_FOUND.status_code,
+                        "code": ErrorMessages.STORE_NOT_FOUND.name,
+                        "message": ErrorMessages.STORE_NOT_FOUND.message,
+                    },
+                ),
+                OpenApiExample(
+                    "store_click 룰 없음",
+                    value={
+                        "status_code": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.status_code,
+                        "code": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.name,
+                        "message": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.message,
+                    },
+                ),
+                OpenApiExample(
+                    "source 룰 없음",
+                    value={
+                        "status_code": ErrorMessages.SOURCE_NOT_FOUND.status_code,
+                        "code": ErrorMessages.SOURCE_NOT_FOUND.name,
+                        "message": ErrorMessages.SOURCE_NOT_FOUND.message,
+                    },
+                ),
+            ],
+        ),
+    },
+)
+class InteractionStoreClickLogCreateView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request) -> Response:
+        serializer = InteractionStoreClickLogRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        user = cast(User, request.user)
+        log, created = record_store_click_interaction(
+            user=user,
+            game_id=data["game_id"],
+            store_id=data["store_id"],
+            source=data["source"],
+            metadata=data.get("metadata"),
+        )
+
+        response_serializer = InteractionStoreClickLogResponseSerializer(log)
         return Response(response_serializer.data, status=201 if created else 200)

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -187,7 +187,7 @@ class InteractionViewLogCreateView(APIView):
             value={
                 "id": 201,
                 "type": "search",
-                "created_at": "2026-03-11T08:30:00Z",
+                "logged_at": "2026-03-11T08:30:00Z",
             },
             response_only=True,
             status_codes=["201"],
@@ -197,7 +197,7 @@ class InteractionViewLogCreateView(APIView):
             value={
                 "id": 201,
                 "type": "search",
-                "created_at": "2026-03-11T08:30:00Z",
+                "logged_at": "2026-03-11T08:30:00Z",
             },
             response_only=True,
             status_codes=["200"],
@@ -332,7 +332,7 @@ class InteractionSearchLogCreateView(APIView):
             value={
                 "id": 301,
                 "type": "store_click",
-                "routed_at": "2026-03-11T08:30:00Z",
+                "logged_at": "2026-03-11T08:30:00Z",
             },
             response_only=True,
             status_codes=["201"],
@@ -342,7 +342,7 @@ class InteractionSearchLogCreateView(APIView):
             value={
                 "id": 301,
                 "type": "store_click",
-                "routed_at": "2026-03-11T08:30:00Z",
+                "logged_at": "2026-03-11T08:30:00Z",
             },
             response_only=True,
             status_codes=["200"],


### PR DESCRIPTION
## ✅ PR 요약
-interactions 응답 필드 네이밍과 서비스 로직 정책을 일관되게 정리

## 📄 상세 내용
- [x] 응답 필드 네이밍 정리
- [x] repeat decay 계산 로직 정합성 점검 및 정리
- [x] serializer/서비스/테스트/스웨거 문서 간 스펙 일치화

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] 빌드/린트가 통과합니다. (가능한 경우)

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
