### PR TITLE
 [Feature/recommendations] 개인화 추천 목록 조회 API,  추천 작업 자동 큐잉 추가

### DIFF
--- a/apps/core/exceptions/exception_message.py
+++ b/apps/core/exceptions/exception_message.py
@@ -45,6 +45,9 @@ class ErrorMessages(Enum):
     INVALID_REFRESH_TOKEN = (401, "유효하지 않은 리프레시 토큰입니다.")
     REFRESH_TOKEN_EXPIRED = (401, "리프레시 토큰이 만료되었습니다.")
 
+    # 202 Accepted
+    RECOMMENDATION_NOT_READY = (202, "추천 데이터를 준비중입니다 잠시 후 다시 요청해주세요.")
+
     # 403 Forbidden
     FORBIDDEN = (403, "관리자 권한이 필요합니다.")
     ADULT_VERIFICATION_REQUIRED = (403, "성인 인증이 필요한 게임입니다.")

--- a/apps/interactions/migrations/0003_interactionlog_store_and_index.py
+++ b/apps/interactions/migrations/0003_interactionlog_store_and_index.py
@@ -1,0 +1,27 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("games", "0003_alter_game_esrb_rating"),
+        ("interactions", "0002_remove_interactioncontextrule_created_at_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="interactionlog",
+            name="store",
+            field=models.ForeignKey(
+                blank=True,
+                db_column="store_id",
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="games.externalstore",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="interactionlog",
+            index=models.Index(fields=["store"], name="interaction_store_i_4e10f0_idx"),
+        ),
+    ]

--- a/apps/interactions/models/interaction_log.py
+++ b/apps/interactions/models/interaction_log.py
@@ -39,6 +39,14 @@ class InteractionLog(models.Model):
         blank=True,
     )
 
+    store = models.ForeignKey(
+        "games.ExternalStore",
+        on_delete=models.CASCADE,
+        db_column="store_id",
+        null=True,
+        blank=True,
+    )
+
     search_query = models.TextField(
         null=True,
         blank=True,
@@ -75,6 +83,7 @@ class InteractionLog(models.Model):
         indexes = [
             models.Index(fields=["user"]),
             models.Index(fields=["game"]),
+            models.Index(fields=["store"]),
             models.Index(fields=["type"]),
             models.Index(fields=["created_at"]),
         ]

--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -10,6 +10,7 @@ from apps.interactions.models import InteractionLog
 
 
 class InteractionViewLogRequestSerializer(serializers.Serializer[dict[str, Any]]):
+    # 커스텀 통합 에러코드(GAME_ID_OR_SOURCE_MISSING)를 유지하기 위해 required=False 후 validate에서 검사한다.
     game_id = serializers.IntegerField(min_value=1, required=False)
     source = serializers.CharField(required=False)  # type: ignore[assignment]
     metadata = serializers.JSONField(required=False)
@@ -33,6 +34,7 @@ class InteractionViewLogResponseSerializer(serializers.Serializer):  # type: ign
 
 
 class InteractionSearchLogRequestSerializer(serializers.Serializer[dict[str, Any]]):
+    # 커스텀 통합/도메인 에러코드 유지를 위해 required=False 후 validate에서 검사한다.
     game_id = serializers.IntegerField(min_value=1, required=False)
     search_query = serializers.CharField(required=False)
     source = serializers.CharField(required=False)  # type: ignore[assignment]
@@ -54,10 +56,11 @@ class InteractionSearchLogRequestSerializer(serializers.Serializer[dict[str, Any
 class InteractionSearchLogResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
     id = serializers.IntegerField()
     type = serializers.CharField()
-    created_at = serializers.DateTimeField()
+    logged_at = serializers.DateTimeField(source="created_at")
 
 
 class InteractionStoreClickLogRequestSerializer(serializers.Serializer[dict[str, Any]]):
+    # 커스텀 통합 에러코드 유지를 위해 required=False 후 validate에서 검사한다.
     game_id = serializers.IntegerField(min_value=1, required=False)
     store_id = serializers.IntegerField(min_value=1, required=False)
     source = serializers.CharField(required=False)  # type: ignore[assignment]
@@ -79,4 +82,4 @@ class InteractionStoreClickLogRequestSerializer(serializers.Serializer[dict[str,
 class InteractionStoreClickLogResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
     id = serializers.IntegerField()
     type = serializers.CharField()
-    routed_at = serializers.DateTimeField(source="created_at")
+    logged_at = serializers.DateTimeField(source="created_at")

--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -55,3 +55,28 @@ class InteractionSearchLogResponseSerializer(serializers.Serializer):  # type: i
     id = serializers.IntegerField()
     type = serializers.CharField()
     created_at = serializers.DateTimeField()
+
+
+class InteractionStoreClickLogRequestSerializer(serializers.Serializer[dict[str, Any]]):
+    game_id = serializers.IntegerField(min_value=1, required=False)
+    store_id = serializers.IntegerField(min_value=1, required=False)
+    source = serializers.CharField(required=False)  # type: ignore[assignment]
+    metadata = serializers.JSONField(required=False)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if attrs.get("game_id") is None or attrs.get("store_id") is None:
+            raise CustomAPIException(ErrorMessages.GAME_ID_OR_STORE_ID_MISSING)
+        if attrs.get("source") is None:
+            raise CustomAPIException(ErrorMessages.GAME_ID_OR_SOURCE_MISSING)
+        return attrs
+
+    def validate_source(self, value: str) -> str:
+        if value != InteractionLog.SourceType.DETAIL_PAGE:
+            raise CustomAPIException(ErrorMessages.INVALID_SOURCE)
+        return value
+
+
+class InteractionStoreClickLogResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    id = serializers.IntegerField()
+    type = serializers.CharField()
+    routed_at = serializers.DateTimeField(source="created_at")

--- a/apps/interactions/services/__init__.py
+++ b/apps/interactions/services/__init__.py
@@ -1,3 +1,7 @@
-from .view_log_service import record_search_interaction, record_view_interaction
+from .view_log_service import (
+    record_search_interaction,
+    record_store_click_interaction,
+    record_view_interaction,
+)
 
-__all__ = ["record_view_interaction", "record_search_interaction"]
+__all__ = ["record_view_interaction", "record_search_interaction", "record_store_click_interaction"]

--- a/apps/interactions/services/view_log_service.py
+++ b/apps/interactions/services/view_log_service.py
@@ -13,6 +13,9 @@ from apps.games.models import ExternalStore, Game, GameStore
 from apps.interactions.models import InteractionContextRule, InteractionLog, InteractionWeightRule
 from apps.users.models import User
 
+MAX_EFFECTIVE_REPEAT_COUNT = 10
+WEIGHT_QUANTIZE_UNIT = Decimal("0.0001")
+
 
 def record_view_interaction(
     *,
@@ -69,10 +72,10 @@ def record_view_interaction(
             game=game,
             type=InteractionLog.ActionType.VIEW,
         ).count()
-        effective_repeat_count = min(repeat_count, 10)
+        effective_repeat_count = min(repeat_count, MAX_EFFECTIVE_REPEAT_COUNT)
         weight: Decimal = (
             weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**effective_repeat_count)
-        ).quantize(Decimal("0.0001"))
+        ).quantize(WEIGHT_QUANTIZE_UNIT)
 
         log = InteractionLog.objects.create(
             user=user,
@@ -142,10 +145,10 @@ def record_search_interaction(
             game=game,
             type=InteractionLog.ActionType.SEARCH,
         ).count()
-        effective_repeat_count = min(repeat_count, 10)
+        effective_repeat_count = min(repeat_count, MAX_EFFECTIVE_REPEAT_COUNT)
         weight: Decimal = (
             weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**effective_repeat_count)
-        ).quantize(Decimal("0.0001"))
+        ).quantize(WEIGHT_QUANTIZE_UNIT)
 
         log = InteractionLog.objects.create(
             user=user,
@@ -223,10 +226,10 @@ def record_store_click_interaction(
             store=store,
             type=InteractionLog.ActionType.STORE_CLICK,
         ).count()
-        effective_repeat_count = min(repeat_count, 10)
+        effective_repeat_count = min(repeat_count, MAX_EFFECTIVE_REPEAT_COUNT)
         weight: Decimal = (
             weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**effective_repeat_count)
-        ).quantize(Decimal("0.0001"))
+        ).quantize(WEIGHT_QUANTIZE_UNIT)
 
         log = InteractionLog.objects.create(
             user=user,

--- a/apps/interactions/services/view_log_service.py
+++ b/apps/interactions/services/view_log_service.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
-from apps.games.models import Game
+from apps.games.models import ExternalStore, Game, GameStore
 from apps.interactions.models import InteractionContextRule, InteractionLog, InteractionWeightRule
 from apps.users.models import User
 
@@ -153,6 +153,87 @@ def record_search_interaction(
             type=InteractionLog.ActionType.SEARCH,
             source=source,
             search_query=search_query,
+            weight=weight,
+            metadata=metadata,
+        )
+        return log, True
+
+
+def record_store_click_interaction(
+    *,
+    user: User,
+    game_id: int,
+    store_id: int,
+    source: str,
+    metadata: dict[str, object] | list[object] | str | int | float | bool | None = None,
+) -> tuple[InteractionLog, bool]:
+    if metadata is not None:
+        try:
+            json.dumps(metadata)
+        except (TypeError, ValueError):
+            raise CustomAPIException(ErrorMessages.VALIDATION_ERROR) from None
+
+    game = Game.objects.filter(id=game_id, is_visible=True).first()
+    if game is None:
+        raise CustomAPIException(ErrorMessages.GAME_NOT_FOUND) from None
+
+    store = ExternalStore.objects.filter(id=store_id).first()
+    if store is None:
+        raise CustomAPIException(ErrorMessages.STORE_NOT_FOUND) from None
+    if not GameStore.objects.filter(game=game, store=store).exists():
+        raise CustomAPIException(ErrorMessages.STORE_NOT_FOUND) from None
+
+    weight_rule = InteractionWeightRule.objects.filter(
+        interaction_type=InteractionLog.ActionType.STORE_CLICK,
+        is_active=True,
+    ).first()
+    if weight_rule is None:
+        raise CustomAPIException(ErrorMessages.INTERACTION_TYPE_NOT_FOUND) from None
+
+    context_rule = InteractionContextRule.objects.filter(interaction_source=source).first()
+    if context_rule is None:
+        raise CustomAPIException(ErrorMessages.SOURCE_NOT_FOUND) from None
+
+    with transaction.atomic():
+        # 동일 사용자 요청을 직렬화해 cooldown 체크-생성 사이 경쟁 조건을 줄인다.
+        User.objects.select_for_update().get(pk=user.pk)
+
+        latest_reusable_log = (
+            InteractionLog.objects.filter(
+                user=user,
+                game=game,
+                store=store,
+                type=InteractionLog.ActionType.STORE_CLICK,
+                source=source,
+                weight__isnull=False,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if (
+            latest_reusable_log is not None
+            and weight_rule.cooldown_seconds > 0
+            and latest_reusable_log.created_at >= timezone.now() - timedelta(seconds=weight_rule.cooldown_seconds)
+        ):
+            return latest_reusable_log, False
+
+        repeat_count = InteractionLog.objects.filter(
+            user=user,
+            game=game,
+            store=store,
+            type=InteractionLog.ActionType.STORE_CLICK,
+        ).count()
+        effective_repeat_count = min(repeat_count, 10)
+        weight: Decimal = (
+            weight_rule.base_weight * context_rule.multiplier * (weight_rule.repeat_decay**effective_repeat_count)
+        ).quantize(Decimal("0.0001"))
+
+        log = InteractionLog.objects.create(
+            user=user,
+            game=game,
+            store=store,
+            type=InteractionLog.ActionType.STORE_CLICK,
+            source=source,
             weight=weight,
             metadata=metadata,
         )

--- a/apps/interactions/tests.py
+++ b/apps/interactions/tests.py
@@ -394,7 +394,7 @@ class InteractionSearchLogCreateAPITestCase(TestCase):
         data = cast(dict[str, Any], response.data)
         self.assertIn("id", data)
         self.assertEqual(data["type"], "search")
-        self.assertIn("created_at", data)
+        self.assertIn("logged_at", data)
 
         log = InteractionLog.objects.get(id=data["id"])
         self.assertEqual(log.user_id, user.id)
@@ -683,7 +683,7 @@ class InteractionStoreClickLogCreateAPITestCase(TestCase):
         data = cast(dict[str, Any], response.data)
         self.assertIn("id", data)
         self.assertEqual(data["type"], "store_click")
-        self.assertIn("routed_at", data)
+        self.assertIn("logged_at", data)
 
         log = InteractionLog.objects.get(id=data["id"])
         self.assertEqual(log.user_id, user.id)

--- a/apps/interactions/tests.py
+++ b/apps/interactions/tests.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from django.utils import timezone
 from rest_framework.test import APIClient
 
-from apps.games.models import Game
+from apps.games.models import ExternalStore, Game, GameStore
 from apps.interactions.models import InteractionContextRule, InteractionLog, InteractionWeightRule
 from apps.users.models import User
 
@@ -508,3 +508,304 @@ class InteractionSearchLogCreateAPITestCase(TestCase):
         second_log = InteractionLog.objects.get(id=second_id)
         self.assertIsNotNone(second_log.weight)
         self.assertEqual(float(cast(Any, second_log.weight)), 0.099)  # 0.1 * 1.1 * 0.9^1
+
+
+class InteractionStoreClickLogCreateAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/interactions/store-click/"
+        self._create_store_click_rules()
+
+    def _create_user(self) -> User:
+        return User.objects.create_user(
+            email="store-user@ex.com",
+            nickname="store-user",
+            birth_date=date(1993, 1, 1),
+            password="pw",
+        )
+
+    def _create_game(self, **kwargs: Any) -> Game:
+        defaults = {
+            "rawg_id": 8001,
+            "slug": "store-click-game",
+            "name": "Store Click Game",
+            "thumbnail_img_url": "https://example.com/store-thumb.jpg",
+            "website": "https://example.com/store-game",
+            "rawg_rating": 4.10,
+            "is_visible": True,
+        }
+        defaults.update(kwargs)
+        return Game.objects.create(**defaults)
+
+    def _create_store(self, **kwargs: Any) -> ExternalStore:
+        defaults = {
+            "rawg_id": 1001,
+            "name": "Steam",
+            "slug": "steam",
+            "domain": "store.steampowered.com",
+            "icon_url": "https://example.com/store-icon.png",
+        }
+        defaults.update(kwargs)
+        return ExternalStore.objects.create(**defaults)
+
+    def _create_game_store(self, game: Game, store: ExternalStore, **kwargs: Any) -> GameStore:
+        defaults = {"url": "https://store.steampowered.com/app/123"}
+        defaults.update(kwargs)
+        return GameStore.objects.create(game=game, store=store, **defaults)
+
+    def _create_store_click_rules(self) -> None:
+        InteractionWeightRule.objects.create(
+            interaction_type=InteractionWeightRule.ActionType.STORE_CLICK,
+            base_weight=0.10,
+            cooldown_seconds=120,
+            repeat_decay=0.900,
+            is_active=True,
+        )
+        InteractionContextRule.objects.get_or_create(
+            interaction_source=InteractionContextRule.InteractionSource.DETAIL_PAGE,
+            defaults={"multiplier": 1.20},
+        )
+
+    def test_interaction_store_click_unauthorized(self) -> None:
+        response = self.client.post(
+            self.url,
+            {"game_id": 1, "store_id": 1, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_interaction_store_click_missing_required_returns_400(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": 1, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "GAME_ID_OR_STORE_ID_MISSING")
+
+    def test_interaction_store_click_missing_source_returns_400(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": 1, "store_id": 1},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "GAME_ID_OR_SOURCE_MISSING")
+
+    def test_interaction_store_click_invalid_source_returns_400(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "search_result"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "INVALID_SOURCE")
+
+    def test_interaction_store_click_game_not_found_returns_404(self) -> None:
+        user = self._create_user()
+        store = self._create_store()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": 999999, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "GAME_NOT_FOUND")
+
+    def test_interaction_store_click_store_not_found_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": 999999, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "STORE_NOT_FOUND")
+
+    def test_interaction_store_click_unlinked_store_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "STORE_NOT_FOUND")
+
+    def test_interaction_store_click_success(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.url,
+            {
+                "game_id": game.id,
+                "store_id": store.id,
+                "source": "detail_page",
+                "metadata": {"button_position": "hero"},
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+
+        data = cast(dict[str, Any], response.data)
+        self.assertIn("id", data)
+        self.assertEqual(data["type"], "store_click")
+        self.assertIn("routed_at", data)
+
+        log = InteractionLog.objects.get(id=data["id"])
+        self.assertEqual(log.user_id, user.id)
+        self.assertEqual(log.game_id, game.id)
+        self.assertEqual(log.store_id, store.id)
+        self.assertEqual(log.type, InteractionLog.ActionType.STORE_CLICK)
+        self.assertEqual(log.source, InteractionLog.SourceType.DETAIL_PAGE)
+        self.assertIsNotNone(log.weight)
+        self.assertEqual(float(cast(Any, log.weight)), 0.12)
+
+    def test_interaction_store_click_cooldown_ignored_returns_200(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(InteractionLog.objects.count(), 1)
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(InteractionLog.objects.count(), 1)
+
+    def test_interaction_store_click_different_store_is_logged_even_in_cooldown(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store_a = self._create_store(rawg_id=1001, slug="steam", name="Steam")
+        store_b = self._create_store(rawg_id=1002, slug="gog", name="GOG", domain="gog.com")
+        self._create_game_store(game=game, store=store_a)
+        self._create_game_store(game=game, store=store_b, url="https://gog.com/game/123")
+        self.client.force_authenticate(user=user)
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store_a.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store_b.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 201)
+        self.assertEqual(InteractionLog.objects.count(), 2)
+
+    def test_interaction_store_click_missing_weight_rule_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+        InteractionWeightRule.objects.filter(interaction_type=InteractionWeightRule.ActionType.STORE_CLICK).delete()
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "INTERACTION_TYPE_NOT_FOUND")
+
+    def test_interaction_store_click_missing_source_rule_returns_404(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+        InteractionContextRule.objects.filter(
+            interaction_source=InteractionContextRule.InteractionSource.DETAIL_PAGE
+        ).delete()
+
+        response = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "SOURCE_NOT_FOUND")
+
+    def test_interaction_store_click_repeat_decay_applied_per_store(self) -> None:
+        user = self._create_user()
+        game = self._create_game()
+        store = self._create_store()
+        self._create_game_store(game=game, store=store)
+        self.client.force_authenticate(user=user)
+        InteractionWeightRule.objects.filter(interaction_type=InteractionWeightRule.ActionType.STORE_CLICK).update(
+            cooldown_seconds=0,
+            repeat_decay=0.900,
+        )
+
+        first = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201)
+        first_id = cast(dict[str, Any], first.data)["id"]
+        first_log = InteractionLog.objects.get(id=first_id)
+        self.assertIsNotNone(first_log.weight)
+        self.assertEqual(float(cast(Any, first_log.weight)), 0.12)  # 0.1 * 1.2 * 0.9^0
+
+        second = self.client.post(
+            self.url,
+            {"game_id": game.id, "store_id": store.id, "source": "detail_page"},
+            format="json",
+        )
+        self.assertEqual(second.status_code, 201)
+        second_id = cast(dict[str, Any], second.data)["id"]
+        second_log = InteractionLog.objects.get(id=second_id)
+        self.assertIsNotNone(second_log.weight)
+        self.assertEqual(float(cast(Any, second_log.weight)), 0.108)  # 0.1 * 1.2 * 0.9^1

--- a/apps/interactions/urls.py
+++ b/apps/interactions/urls.py
@@ -1,8 +1,13 @@
 from django.urls import path
 
-from apps.interactions.views import InteractionSearchLogCreateView, InteractionViewLogCreateView
+from apps.interactions.views import (
+    InteractionSearchLogCreateView,
+    InteractionStoreClickLogCreateView,
+    InteractionViewLogCreateView,
+)
 
 urlpatterns = [
     path("view/", InteractionViewLogCreateView.as_view(), name="interaction-view-create"),
     path("search/", InteractionSearchLogCreateView.as_view(), name="interaction-search-create"),
+    path("store-click/", InteractionStoreClickLogCreateView.as_view(), name="interaction-store-click-create"),
 ]

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -13,10 +13,16 @@ from apps.core.serializers.error_serializer import ErrorResponseSerializer
 from apps.interactions.serializers import (
     InteractionSearchLogRequestSerializer,
     InteractionSearchLogResponseSerializer,
+    InteractionStoreClickLogRequestSerializer,
+    InteractionStoreClickLogResponseSerializer,
     InteractionViewLogRequestSerializer,
     InteractionViewLogResponseSerializer,
 )
-from apps.interactions.services import record_search_interaction, record_view_interaction
+from apps.interactions.services import (
+    record_search_interaction,
+    record_store_click_interaction,
+    record_view_interaction,
+)
 from apps.users.models import User
 
 
@@ -294,4 +300,157 @@ class InteractionSearchLogCreateView(APIView):
         )
 
         response_serializer = InteractionSearchLogResponseSerializer(log)
+        return Response(response_serializer.data, status=201 if created else 200)
+
+
+@extend_schema(
+    tags=["Interactions"],
+    summary="외부 스토어 이동 행동 기록",
+    description=(
+        "게임 상세 페이지에서 외부 스토어 이동(store_click) 행동을 기록합니다.\n\n"
+        "- 이 API는 `source=detail_page`만 허용합니다.\n"
+        "- 최초 기록 시: `201`\n"
+        "- 동일 game/store/source에서 쿨다운 내 중복 요청 시: 로그를 추가 생성하지 않고 `200`으로 기존 최근 로그를 반환합니다.\n"
+        "- 반복 감쇠(repeat_decay) 계산은 `user + game + store + type` 기준으로 적용됩니다.\n"
+        "- 가중치는 `interaction_weight_rules`(type=store_click)와 "
+        "`interaction_context_rules`(source=detail_page) 조합으로 계산됩니다."
+    ),
+    request=InteractionStoreClickLogRequestSerializer,
+    examples=[
+        OpenApiExample(
+            "요청 예시",
+            value={
+                "game_id": 1,
+                "store_id": 3,
+                "source": "detail_page",
+                "metadata": {"button_position": "hero", "cta_variant": "primary"},
+            },
+            request_only=True,
+        ),
+        OpenApiExample(
+            "생성 응답 예시 (201)",
+            value={
+                "id": 301,
+                "type": "store_click",
+                "routed_at": "2026-03-11T08:30:00Z",
+            },
+            response_only=True,
+            status_codes=["201"],
+        ),
+        OpenApiExample(
+            "쿨다운 무시 응답 예시 (200)",
+            value={
+                "id": 301,
+                "type": "store_click",
+                "routed_at": "2026-03-11T08:30:00Z",
+            },
+            response_only=True,
+            status_codes=["200"],
+        ),
+    ],
+    responses={
+        200: InteractionStoreClickLogResponseSerializer,
+        201: InteractionStoreClickLogResponseSerializer,
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Bad Request",
+            examples=[
+                OpenApiExample(
+                    "game_id/store_id 누락",
+                    value={
+                        "status_code": ErrorMessages.GAME_ID_OR_STORE_ID_MISSING.status_code,
+                        "code": ErrorMessages.GAME_ID_OR_STORE_ID_MISSING.name,
+                        "message": ErrorMessages.GAME_ID_OR_STORE_ID_MISSING.message,
+                    },
+                ),
+                OpenApiExample(
+                    "source 누락",
+                    value={
+                        "status_code": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.status_code,
+                        "code": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.name,
+                        "message": ErrorMessages.GAME_ID_OR_SOURCE_MISSING.message,
+                    },
+                ),
+                OpenApiExample(
+                    "source 값 오류",
+                    value={
+                        "status_code": ErrorMessages.INVALID_SOURCE.status_code,
+                        "code": ErrorMessages.INVALID_SOURCE.name,
+                        "message": ErrorMessages.INVALID_SOURCE.message,
+                    },
+                ),
+            ],
+        ),
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Unauthorized",
+            examples=[
+                OpenApiExample(
+                    "인증 필요",
+                    value={
+                        "status_code": ErrorMessages.UNAUTHORIZED.status_code,
+                        "code": ErrorMessages.UNAUTHORIZED.name,
+                        "message": ErrorMessages.UNAUTHORIZED.message,
+                    },
+                )
+            ],
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Not Found",
+            examples=[
+                OpenApiExample(
+                    "게임 없음",
+                    value={
+                        "status_code": ErrorMessages.GAME_NOT_FOUND.status_code,
+                        "code": ErrorMessages.GAME_NOT_FOUND.name,
+                        "message": ErrorMessages.GAME_NOT_FOUND.message,
+                    },
+                ),
+                OpenApiExample(
+                    "스토어 없음",
+                    value={
+                        "status_code": ErrorMessages.STORE_NOT_FOUND.status_code,
+                        "code": ErrorMessages.STORE_NOT_FOUND.name,
+                        "message": ErrorMessages.STORE_NOT_FOUND.message,
+                    },
+                ),
+                OpenApiExample(
+                    "store_click 룰 없음",
+                    value={
+                        "status_code": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.status_code,
+                        "code": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.name,
+                        "message": ErrorMessages.INTERACTION_TYPE_NOT_FOUND.message,
+                    },
+                ),
+                OpenApiExample(
+                    "source 룰 없음",
+                    value={
+                        "status_code": ErrorMessages.SOURCE_NOT_FOUND.status_code,
+                        "code": ErrorMessages.SOURCE_NOT_FOUND.name,
+                        "message": ErrorMessages.SOURCE_NOT_FOUND.message,
+                    },
+                ),
+            ],
+        ),
+    },
+)
+class InteractionStoreClickLogCreateView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request) -> Response:
+        serializer = InteractionStoreClickLogRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        user = cast(User, request.user)
+        log, created = record_store_click_interaction(
+            user=user,
+            game_id=data["game_id"],
+            store_id=data["store_id"],
+            source=data["source"],
+            metadata=data.get("metadata"),
+        )
+
+        response_serializer = InteractionStoreClickLogResponseSerializer(log)
         return Response(response_serializer.data, status=201 if created else 200)

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -187,7 +187,7 @@ class InteractionViewLogCreateView(APIView):
             value={
                 "id": 201,
                 "type": "search",
-                "created_at": "2026-03-11T08:30:00Z",
+                "logged_at": "2026-03-11T08:30:00Z",
             },
             response_only=True,
             status_codes=["201"],
@@ -197,7 +197,7 @@ class InteractionViewLogCreateView(APIView):
             value={
                 "id": 201,
                 "type": "search",
-                "created_at": "2026-03-11T08:30:00Z",
+                "logged_at": "2026-03-11T08:30:00Z",
             },
             response_only=True,
             status_codes=["200"],
@@ -332,7 +332,7 @@ class InteractionSearchLogCreateView(APIView):
             value={
                 "id": 301,
                 "type": "store_click",
-                "routed_at": "2026-03-11T08:30:00Z",
+                "logged_at": "2026-03-11T08:30:00Z",
             },
             response_only=True,
             status_codes=["201"],
@@ -342,7 +342,7 @@ class InteractionSearchLogCreateView(APIView):
             value={
                 "id": 301,
                 "type": "store_click",
-                "routed_at": "2026-03-11T08:30:00Z",
+                "logged_at": "2026-03-11T08:30:00Z",
             },
             response_only=True,
             status_codes=["200"],

--- a/apps/recommendations/serializers.py
+++ b/apps/recommendations/serializers.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from rest_framework import serializers
+
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.recommendations.models import UserRecommendation
+
+
+class RecommendationQuerySerializer(serializers.Serializer[dict[str, Any]]):
+    type = serializers.CharField(required=False)
+    genre = serializers.CharField(required=False)
+    tag = serializers.CharField(required=False)
+    is_free = serializers.BooleanField(required=False)
+    is_adult = serializers.BooleanField(required=False)
+
+    def validate_type(self, value: str) -> str:
+        allowed = {choice for choice, _ in UserRecommendation.ReasonType.choices}
+        if value not in allowed:
+            raise CustomAPIException(ErrorMessages.INVALID_QUERY_PARAM)
+        return value
+
+    def validate_genre(self, value: str | None) -> list[int]:
+        return self._parse_int_list(value)
+
+    def validate_tag(self, value: str | None) -> list[int]:
+        return self._parse_int_list(value)
+
+    def _parse_int_list(self, value: str | None) -> list[int]:
+        if not value:
+            return []
+        try:
+            return [int(x) for x in value.split(",") if x]
+        except ValueError:
+            raise CustomAPIException(ErrorMessages.INVALID_QUERY_PARAM) from None
+
+
+class RecommendationGenreSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+
+
+class RecommendationItemSerializer(serializers.ModelSerializer[UserRecommendation]):
+    game_id = serializers.IntegerField(source="game.id")
+    name = serializers.CharField(source="game.name")
+    thumbnail_img_url = serializers.CharField(source="game.thumbnail_img_url")
+    rawg_rating = serializers.DecimalField(source="game.rawg_rating", max_digits=3, decimal_places=2)
+    tags = serializers.SerializerMethodField()
+    genres = serializers.SerializerMethodField()
+
+    class Meta:
+        model = UserRecommendation
+        fields = [
+            "game_id",
+            "name",
+            "reason",
+            "generated_at",
+            "rank",
+            "score",
+            "tags",
+            "thumbnail_img_url",
+            "rawg_rating",
+            "genres",
+        ]
+
+    def get_tags(self, obj: UserRecommendation) -> list[str]:
+        return [gt.tag.name for gt in obj.game.game_tags.all()]
+
+    def get_genres(self, obj: UserRecommendation) -> list[dict[str, Any]]:
+        return cast(
+            list[dict[str, Any]],
+            RecommendationGenreSerializer(
+                [{"id": gg.genre.id, "name": gg.genre.name} for gg in obj.game.game_genres.all()],
+                many=True,
+            ).data,
+        )
+
+
+class RecommendationListResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    count = serializers.IntegerField()
+    next = serializers.CharField(allow_null=True)
+    previous = serializers.CharField(allow_null=True)
+    results = RecommendationItemSerializer(many=True)

--- a/apps/recommendations/services.py
+++ b/apps/recommendations/services.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from django.db.models import QuerySet
+
+from apps.recommendations.models import RecommendationJob, UserRecommendation
+from apps.users.models import User
+
+
+class RecommendationService:
+    @staticmethod
+    def is_recommendation_ready(*, user: User) -> bool:
+        latest_user_refresh_job = (
+            RecommendationJob.objects.filter(
+                target_user=user,
+                job_type=RecommendationJob.JobType.USER_REFRESH,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if latest_user_refresh_job is not None and latest_user_refresh_job.status in {
+            RecommendationJob.Status.PENDING,
+            RecommendationJob.Status.RUNNING,
+        }:
+            return False
+
+        has_visible_recommendation = UserRecommendation.objects.filter(user=user, game__is_visible=True).exists()
+        return has_visible_recommendation
+
+    @staticmethod
+    def list_recommendations(
+        *,
+        user: User,
+        rec_type: str | None = None,
+        genre_ids: list[int] | None = None,
+        tag_ids: list[int] | None = None,
+        is_adult: bool | None = None,
+        is_free: bool | None = None,
+    ) -> QuerySet[UserRecommendation]:
+        qs = (
+            UserRecommendation.objects.filter(user=user, game__is_visible=True)
+            .select_related("game")
+            .prefetch_related("game__game_genres__genre", "game__game_tags__tag")
+        )
+
+        if rec_type:
+            qs = qs.filter(reason=rec_type)
+        if genre_ids:
+            qs = qs.filter(game__game_genres__genre_id__in=genre_ids)
+        if tag_ids:
+            qs = qs.filter(game__game_tags__tag_id__in=tag_ids)
+        if is_adult is True:
+            qs = qs.filter(game__age_rating_min__gte=18)
+        elif is_adult is False:
+            qs = qs.filter(game__age_rating_min__lt=18)
+
+        if is_free is not None:
+            pass
+
+        return qs.distinct().order_by("rank")
+
+    @staticmethod
+    def enqueue_user_refresh_job_if_needed(*, user: User) -> RecommendationJob:
+        latest_user_refresh_job = (
+            RecommendationJob.objects.filter(
+                target_user=user,
+                job_type=RecommendationJob.JobType.USER_REFRESH,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if latest_user_refresh_job is not None and latest_user_refresh_job.status in {
+            RecommendationJob.Status.PENDING,
+            RecommendationJob.Status.RUNNING,
+        }:
+            return latest_user_refresh_job
+
+        return RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=user,
+            status=RecommendationJob.Status.PENDING,
+        )

--- a/apps/recommendations/services.py
+++ b/apps/recommendations/services.py
@@ -8,8 +8,8 @@ from apps.users.models import User
 
 class RecommendationService:
     @staticmethod
-    def is_recommendation_ready(*, user: User) -> bool:
-        latest_user_refresh_job = (
+    def _get_latest_user_refresh_job(*, user: User) -> RecommendationJob | None:
+        return (
             RecommendationJob.objects.filter(
                 target_user=user,
                 job_type=RecommendationJob.JobType.USER_REFRESH,
@@ -17,6 +17,10 @@ class RecommendationService:
             .order_by("-created_at")
             .first()
         )
+
+    @staticmethod
+    def is_recommendation_ready(*, user: User) -> bool:
+        latest_user_refresh_job = RecommendationService._get_latest_user_refresh_job(user=user)
         if latest_user_refresh_job is not None and latest_user_refresh_job.status in {
             RecommendationJob.Status.PENDING,
             RecommendationJob.Status.RUNNING,
@@ -60,14 +64,7 @@ class RecommendationService:
 
     @staticmethod
     def enqueue_user_refresh_job_if_needed(*, user: User) -> RecommendationJob:
-        latest_user_refresh_job = (
-            RecommendationJob.objects.filter(
-                target_user=user,
-                job_type=RecommendationJob.JobType.USER_REFRESH,
-            )
-            .order_by("-created_at")
-            .first()
-        )
+        latest_user_refresh_job = RecommendationService._get_latest_user_refresh_job(user=user)
         if latest_user_refresh_job is not None and latest_user_refresh_job.status in {
             RecommendationJob.Status.PENDING,
             RecommendationJob.Status.RUNNING,

--- a/apps/recommendations/tasks.py
+++ b/apps/recommendations/tasks.py
@@ -82,6 +82,10 @@ def _upsert_recommendations(
 
 @shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=3)
 def process_user_refresh_job(self, job_id: int) -> None:  # type: ignore[no-untyped-def]
+    run_user_refresh_job(job_id)
+
+
+def run_user_refresh_job(job_id: int) -> None:
     target_user_id: int | None = None
     current_retry_count = 0
     with transaction.atomic():

--- a/apps/recommendations/tasks.py
+++ b/apps/recommendations/tasks.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+
+from celery import shared_task
+from django.db import transaction
+from django.db.models import Max
+from django.utils import timezone
+
+from apps.games.models import Game
+from apps.interactions.models import InteractionLog
+from apps.recommendations.models import GameSimilarity, RecommendationJob, UserRecommendation
+
+MAX_SEED_GAMES = 20
+MAX_RECENT_LOG_SCAN = 200
+MAX_RECOMMENDATIONS = 50
+RECOMMENDATION_EXPIRE_DAYS = 7
+
+
+def _collect_seed_game_ids(*, user_id: int) -> list[int]:
+    recent_game_ids = list(
+        InteractionLog.objects.filter(user_id=user_id, game_id__isnull=False)
+        .order_by("-created_at")
+        .values_list("game_id", flat=True)[:MAX_RECENT_LOG_SCAN]
+    )
+    unique_seed_game_ids = list(dict.fromkeys(recent_game_ids))
+    return unique_seed_game_ids[:MAX_SEED_GAMES]
+
+
+def _build_similarity_candidates(*, seed_game_ids: list[int], is_adult_verified: bool) -> list[tuple[int, Decimal]]:
+    if not seed_game_ids:
+        return []
+
+    similarity_qs = GameSimilarity.objects.filter(
+        game_id__in=seed_game_ids,
+        similar_game__is_visible=True,
+    ).exclude(similar_game_id__in=seed_game_ids)
+
+    if not is_adult_verified:
+        similarity_qs = similarity_qs.filter(similar_game__age_rating_min__lt=18)
+
+    rows = similarity_qs.values("similar_game_id").annotate(score=Max("score")).order_by("-score")[:MAX_RECOMMENDATIONS]
+    return [(row["similar_game_id"], row["score"]) for row in rows]
+
+
+def _build_fallback_candidates(*, is_adult_verified: bool) -> list[tuple[int, Decimal]]:
+    fallback_qs = Game.objects.filter(is_visible=True)
+    if not is_adult_verified:
+        fallback_qs = fallback_qs.filter(age_rating_min__lt=18)
+
+    rows = fallback_qs.order_by("-rawg_rating")[:MAX_RECOMMENDATIONS].values("id", "rawg_rating")
+    return [(row["id"], (row["rawg_rating"] / Decimal("5")).quantize(Decimal("0.0001"))) for row in rows]
+
+
+def _upsert_recommendations(
+    *,
+    user_id: int,
+    generation_version: int,
+    candidates: list[tuple[int, Decimal]],
+) -> None:
+    now = timezone.now()
+    expires_at = now + timedelta(days=RECOMMENDATION_EXPIRE_DAYS)
+
+    for rank, (game_id, score) in enumerate(candidates, start=1):
+        UserRecommendation.objects.update_or_create(
+            user_id=user_id,
+            game_id=game_id,
+            defaults={
+                "generation_version": generation_version,
+                "score": score,
+                "rank": rank,
+                "reason": UserRecommendation.ReasonType.SIMILARITY,
+                "generated_at": now,
+                "expires_at": expires_at,
+            },
+        )
+
+    UserRecommendation.objects.filter(user_id=user_id).exclude(generation_version=generation_version).delete()
+
+
+@shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=3)
+def process_user_refresh_job(self, job_id: int) -> None:  # type: ignore[no-untyped-def]
+    with transaction.atomic():
+        job = (
+            RecommendationJob.objects.select_for_update()
+            .filter(
+                id=job_id,
+                job_type=RecommendationJob.JobType.USER_REFRESH,
+            )
+            .first()
+        )
+        if job is None or job.target_user_id is None:
+            return
+        if job.status not in {RecommendationJob.Status.PENDING, RecommendationJob.Status.RUNNING}:
+            return
+
+        job.status = RecommendationJob.Status.RUNNING
+        job.started_at = timezone.now()
+        job.error_message = None
+        job.save(update_fields=["status", "started_at", "error_message"])
+
+    try:
+        user = job.target_user
+        seed_game_ids = _collect_seed_game_ids(user_id=user.id)
+        candidates = _build_similarity_candidates(seed_game_ids=seed_game_ids, is_adult_verified=user.is_adult_verified)
+        if not candidates:
+            candidates = _build_fallback_candidates(is_adult_verified=user.is_adult_verified)
+
+        latest_generation = (
+            UserRecommendation.objects.filter(user_id=user.id).aggregate(max_generation=Max("generation_version"))[
+                "max_generation"
+            ]
+            or 0
+        )
+        next_generation = latest_generation + 1
+        _upsert_recommendations(
+            user_id=user.id,
+            generation_version=next_generation,
+            candidates=candidates,
+        )
+
+        RecommendationJob.objects.filter(id=job_id).update(
+            status=RecommendationJob.Status.SUCCESS,
+            finished_at=timezone.now(),
+        )
+    except Exception as err:
+        RecommendationJob.objects.filter(id=job_id).update(
+            status=RecommendationJob.Status.FAILED,
+            finished_at=timezone.now(),
+            retry_count=job.retry_count + 1,
+            error_message=str(err)[:1000],
+        )
+        raise
+
+
+@shared_task
+def process_pending_recommendation_jobs(limit: int = 20) -> int:
+    pending_job_ids = list(
+        RecommendationJob.objects.filter(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            status=RecommendationJob.Status.PENDING,
+            target_user_id__isnull=False,
+        )
+        .order_by("created_at")
+        .values_list("id", flat=True)[:limit]
+    )
+    for job_id in pending_job_ids:
+        process_user_refresh_job.delay(job_id)
+    return len(pending_job_ids)

--- a/apps/recommendations/tasks.py
+++ b/apps/recommendations/tasks.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from apps.games.models import Game
 from apps.interactions.models import InteractionLog
 from apps.recommendations.models import GameSimilarity, RecommendationJob, UserRecommendation
+from apps.users.models import User
 
 MAX_SEED_GAMES = 20
 MAX_RECENT_LOG_SCAN = 200
@@ -81,6 +82,8 @@ def _upsert_recommendations(
 
 @shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=3)
 def process_user_refresh_job(self, job_id: int) -> None:  # type: ignore[no-untyped-def]
+    target_user_id: int | None = None
+    current_retry_count = 0
     with transaction.atomic():
         job = (
             RecommendationJob.objects.select_for_update()
@@ -94,6 +97,8 @@ def process_user_refresh_job(self, job_id: int) -> None:  # type: ignore[no-unty
             return
         if job.status not in {RecommendationJob.Status.PENDING, RecommendationJob.Status.RUNNING}:
             return
+        target_user_id = job.target_user_id
+        current_retry_count = job.retry_count
 
         job.status = RecommendationJob.Status.RUNNING
         job.started_at = timezone.now()
@@ -101,7 +106,9 @@ def process_user_refresh_job(self, job_id: int) -> None:  # type: ignore[no-unty
         job.save(update_fields=["status", "started_at", "error_message"])
 
     try:
-        user = job.target_user
+        if target_user_id is None:
+            return
+        user = User.objects.get(id=target_user_id)
         seed_game_ids = _collect_seed_game_ids(user_id=user.id)
         candidates = _build_similarity_candidates(seed_game_ids=seed_game_ids, is_adult_verified=user.is_adult_verified)
         if not candidates:
@@ -128,7 +135,7 @@ def process_user_refresh_job(self, job_id: int) -> None:  # type: ignore[no-unty
         RecommendationJob.objects.filter(id=job_id).update(
             status=RecommendationJob.Status.FAILED,
             finished_at=timezone.now(),
-            retry_count=job.retry_count + 1,
+            retry_count=current_retry_count + 1,
             error_message=str(err)[:1000],
         )
         raise

--- a/apps/recommendations/tests.py
+++ b/apps/recommendations/tests.py
@@ -162,7 +162,7 @@ class RecommendationListAPITestCase(TestCase):
 
         response = self.client.get(
             self.url,
-            {"type": "similarity", "genre": str(genre_action.id), "tag": str(tag_rpg.id), "is_adult": True},
+            {"type": "similarity", "genre": str(genre_action.id), "tag": str(tag_rpg.id), "is_adult": "true"},
         )
         self.assertEqual(response.status_code, 200)
         payload = cast(dict[str, Any], response.data)

--- a/apps/recommendations/tests.py
+++ b/apps/recommendations/tests.py
@@ -1,1 +1,181 @@
-# Create your tests here.
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any, cast
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from apps.games.models import Game, GameGenre, GameTag, Genre, Tag
+from apps.recommendations.models import RecommendationJob, UserRecommendation
+from apps.users.models import User
+
+
+class RecommendationListAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/recommendations/"
+
+    def _create_user(self) -> User:
+        return User.objects.create_user(
+            email="rec-user@ex.com",
+            nickname="rec-user",
+            birth_date=date(1993, 1, 1),
+            password="pw",
+        )
+
+    def _create_game(
+        self,
+        *,
+        rawg_id: int,
+        slug: str,
+        name: str,
+        is_visible: bool = True,
+        esrb_rating: str = Game.EsrbRating.TEEN,
+    ) -> Game:
+        return Game.objects.create(
+            rawg_id=rawg_id,
+            slug=slug,
+            name=name,
+            thumbnail_img_url="https://example.com/thumb.jpg",
+            website="https://example.com",
+            rawg_rating=Decimal("4.70"),
+            esrb_rating=esrb_rating,
+            is_visible=is_visible,
+        )
+
+    def _create_recommendation(
+        self,
+        *,
+        user: User,
+        game: Game,
+        rank: int,
+        reason: str | None,
+        score: Decimal = Decimal("0.8612"),
+    ) -> UserRecommendation:
+        now = timezone.now()
+        return UserRecommendation.objects.create(
+            user=user,
+            game=game,
+            generation_version=1,
+            score=score,
+            rank=rank,
+            reason=reason,
+            generated_at=now,
+            expires_at=now + timedelta(days=7),
+        )
+
+    def test_recommendation_list_unauthorized(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_recommendation_list_not_ready_when_job_pending(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+        RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=user,
+            status=RecommendationJob.Status.PENDING,
+        )
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 202)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "RECOMMENDATION_NOT_READY")
+        self.assertEqual(
+            RecommendationJob.objects.filter(
+                target_user=user,
+                job_type=RecommendationJob.JobType.USER_REFRESH,
+            ).count(),
+            1,
+        )
+
+    def test_recommendation_list_not_ready_when_no_recommendation(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 202)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "RECOMMENDATION_NOT_READY")
+        queued_job = RecommendationJob.objects.filter(
+            target_user=user,
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+        ).first()
+        self.assertIsNotNone(queued_job)
+        self.assertEqual(cast(RecommendationJob, queued_job).status, RecommendationJob.Status.PENDING)
+
+    def test_recommendation_list_success(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+        game = self._create_game(rawg_id=7001, slug="cp2077", name="Cyberpunk 2077")
+        genre = Genre.objects.create(rawg_id=1, name="Action", slug="action")
+        tag = Tag.objects.create(rawg_id=10, name="RPG", slug="rpg")
+        GameGenre.objects.create(game=game, genre=genre)
+        GameTag.objects.create(game=game, tag=tag)
+        self._create_recommendation(user=user, game=game, rank=1, reason=UserRecommendation.ReasonType.HYBRID)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        payload = cast(dict[str, Any], response.data)
+        self.assertIn("results", payload)
+        self.assertEqual(len(payload["results"]), 1)
+        item = payload["results"][0]
+        self.assertEqual(item["game_id"], game.id)
+        self.assertEqual(item["name"], "Cyberpunk 2077")
+        self.assertEqual(item["reason"], "hybrid")
+        self.assertEqual(item["rank"], 1)
+        self.assertEqual(item["tags"], ["RPG"])
+        self.assertEqual(item["genres"][0]["name"], "Action")
+
+    def test_recommendation_list_filters_type_genre_tag_and_is_adult(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+
+        game_action = self._create_game(
+            rawg_id=7002, slug="action-game", name="Action Game", esrb_rating=Game.EsrbRating.ADULTS_ONLY
+        )
+        game_puzzle = self._create_game(
+            rawg_id=7003, slug="puzzle-game", name="Puzzle Game", esrb_rating=Game.EsrbRating.TEEN
+        )
+
+        genre_action = Genre.objects.create(rawg_id=2, name="Action", slug="action-2")
+        genre_puzzle = Genre.objects.create(rawg_id=3, name="Puzzle", slug="puzzle")
+        tag_rpg = Tag.objects.create(rawg_id=11, name="RPG", slug="rpg-2")
+        tag_cozy = Tag.objects.create(rawg_id=12, name="Cozy", slug="cozy")
+
+        GameGenre.objects.create(game=game_action, genre=genre_action)
+        GameGenre.objects.create(game=game_puzzle, genre=genre_puzzle)
+        GameTag.objects.create(game=game_action, tag=tag_rpg)
+        GameTag.objects.create(game=game_puzzle, tag=tag_cozy)
+
+        self._create_recommendation(
+            user=user, game=game_action, rank=1, reason=UserRecommendation.ReasonType.SIMILARITY
+        )
+        self._create_recommendation(
+            user=user, game=game_puzzle, rank=2, reason=UserRecommendation.ReasonType.PREFERENCE
+        )
+
+        response = self.client.get(
+            self.url,
+            {"type": "similarity", "genre": str(genre_action.id), "tag": str(tag_rpg.id), "is_adult": True},
+        )
+        self.assertEqual(response.status_code, 200)
+        payload = cast(dict[str, Any], response.data)
+        self.assertEqual(len(payload["results"]), 1)
+        self.assertEqual(payload["results"][0]["name"], "Action Game")
+
+    def test_recommendation_list_invalid_query_param_returns_400(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+        game = self._create_game(rawg_id=7004, slug="dummy", name="Dummy")
+        self._create_recommendation(user=user, game=game, rank=1, reason=UserRecommendation.ReasonType.HYBRID)
+
+        response = self.client.get(self.url, {"type": "wrong"})
+        self.assertEqual(response.status_code, 400)
+        payload = cast(dict[str, Any], response.data)
+        self.assertEqual(payload["code"], "INVALID_QUERY_PARAM")

--- a/apps/recommendations/tests.py
+++ b/apps/recommendations/tests.py
@@ -3,13 +3,23 @@ from __future__ import annotations
 from datetime import date, timedelta
 from decimal import Decimal
 from typing import Any, cast
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 from apps.games.models import Game, GameGenre, GameTag, Genre, Tag
+from apps.interactions.models import InteractionLog
 from apps.recommendations.models import RecommendationJob, UserRecommendation
+from apps.recommendations.tasks import (
+    _build_fallback_candidates,
+    _build_similarity_candidates,
+    _collect_seed_game_ids,
+    _upsert_recommendations,
+    process_pending_recommendation_jobs,
+    run_user_refresh_job,
+)
 from apps.users.models import User
 
 
@@ -179,3 +189,203 @@ class RecommendationListAPITestCase(TestCase):
         self.assertEqual(response.status_code, 400)
         payload = cast(dict[str, Any], response.data)
         self.assertEqual(payload["code"], "INVALID_QUERY_PARAM")
+
+    def test_recommendation_list_invalid_genre_query_param_returns_400(self) -> None:
+        user = self._create_user()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(self.url, {"genre": "not-a-number"})
+        self.assertEqual(response.status_code, 400)
+        payload = cast(dict[str, Any], response.data)
+        self.assertEqual(payload["code"], "INVALID_QUERY_PARAM")
+
+
+class RecommendationTaskTestCase(TestCase):
+    def _create_user(self) -> User:
+        return User.objects.create_user(
+            email="task-user@ex.com",
+            nickname="task-user",
+            birth_date=date(1992, 1, 1),
+            password="pw",
+        )
+
+    def _create_game(
+        self,
+        *,
+        rawg_id: int,
+        slug: str,
+        name: str,
+        rawg_rating: Decimal = Decimal("4.20"),
+        esrb_rating: str = Game.EsrbRating.TEEN,
+        is_visible: bool = True,
+    ) -> Game:
+        return Game.objects.create(
+            rawg_id=rawg_id,
+            slug=slug,
+            name=name,
+            thumbnail_img_url="https://example.com/thumb.jpg",
+            website="https://example.com",
+            rawg_rating=rawg_rating,
+            esrb_rating=esrb_rating,
+            is_visible=is_visible,
+        )
+
+    def test_collect_seed_game_ids_returns_latest_unique_ids(self) -> None:
+        user = self._create_user()
+        g1 = self._create_game(rawg_id=8001, slug="g1", name="Game 1")
+        g2 = self._create_game(rawg_id=8002, slug="g2", name="Game 2")
+        g3 = self._create_game(rawg_id=8003, slug="g3", name="Game 3")
+
+        now = timezone.now()
+        l1 = InteractionLog.objects.create(
+            user=user, game=g1, type=InteractionLog.ActionType.VIEW, source=InteractionLog.SourceType.DETAIL_PAGE
+        )
+        l2 = InteractionLog.objects.create(
+            user=user, game=g2, type=InteractionLog.ActionType.VIEW, source=InteractionLog.SourceType.DETAIL_PAGE
+        )
+        l3 = InteractionLog.objects.create(
+            user=user, game=g1, type=InteractionLog.ActionType.VIEW, source=InteractionLog.SourceType.DETAIL_PAGE
+        )
+        l4 = InteractionLog.objects.create(
+            user=user, game=g3, type=InteractionLog.ActionType.VIEW, source=InteractionLog.SourceType.DETAIL_PAGE
+        )
+        InteractionLog.objects.filter(id=l1.id).update(created_at=now - timedelta(minutes=4))
+        InteractionLog.objects.filter(id=l2.id).update(created_at=now - timedelta(minutes=3))
+        InteractionLog.objects.filter(id=l3.id).update(created_at=now - timedelta(minutes=2))
+        InteractionLog.objects.filter(id=l4.id).update(created_at=now - timedelta(minutes=1))
+
+        seed_ids = _collect_seed_game_ids(user_id=user.id)
+        self.assertEqual(seed_ids, [g3.id, g1.id, g2.id])
+
+    def test_build_similarity_candidates_filters_adult_for_non_verified_user(self) -> None:
+        seed = self._create_game(rawg_id=8010, slug="seed", name="Seed")
+        teen = self._create_game(rawg_id=8011, slug="teen", name="Teen", esrb_rating=Game.EsrbRating.TEEN)
+        adult = self._create_game(rawg_id=8012, slug="adult", name="Adult", esrb_rating=Game.EsrbRating.ADULTS_ONLY)
+
+        from apps.recommendations.models import GameSimilarity
+
+        GameSimilarity.objects.create(game=seed, similar_game=teen, score=Decimal("0.7000"))
+        GameSimilarity.objects.create(game=seed, similar_game=adult, score=Decimal("0.9000"))
+
+        non_adult_candidates = _build_similarity_candidates(seed_game_ids=[seed.id], is_adult_verified=False)
+        self.assertEqual(non_adult_candidates, [(teen.id, Decimal("0.7000"))])
+
+        adult_candidates = _build_similarity_candidates(seed_game_ids=[seed.id], is_adult_verified=True)
+        self.assertEqual(adult_candidates, [(adult.id, Decimal("0.9000")), (teen.id, Decimal("0.7000"))])
+
+    def test_build_fallback_candidates_applies_visibility_and_adult_filter(self) -> None:
+        teen = self._create_game(rawg_id=8021, slug="f-teen", name="Fallback Teen", rawg_rating=Decimal("4.80"))
+        self._create_game(
+            rawg_id=8022,
+            slug="f-adult",
+            name="Fallback Adult",
+            rawg_rating=Decimal("4.90"),
+            esrb_rating=Game.EsrbRating.ADULTS_ONLY,
+        )
+        self._create_game(
+            rawg_id=8023,
+            slug="f-hidden",
+            name="Fallback Hidden",
+            rawg_rating=Decimal("5.00"),
+            is_visible=False,
+        )
+
+        non_adult = _build_fallback_candidates(is_adult_verified=False)
+        self.assertEqual(non_adult, [(teen.id, Decimal("0.9600"))])
+
+    def test_upsert_recommendations_replaces_old_generation(self) -> None:
+        user = self._create_user()
+        old_game = self._create_game(rawg_id=8031, slug="old-game", name="Old")
+        g1 = self._create_game(rawg_id=8032, slug="new-g1", name="New 1")
+        g2 = self._create_game(rawg_id=8033, slug="new-g2", name="New 2")
+        now = timezone.now()
+        UserRecommendation.objects.create(
+            user=user,
+            game=old_game,
+            generation_version=1,
+            score=Decimal("0.1000"),
+            rank=1,
+            reason=UserRecommendation.ReasonType.SIMILARITY,
+            generated_at=now,
+            expires_at=now + timedelta(days=1),
+        )
+
+        _upsert_recommendations(
+            user_id=user.id,
+            generation_version=2,
+            candidates=[(g1.id, Decimal("0.9000")), (g2.id, Decimal("0.8000"))],
+        )
+
+        recs = UserRecommendation.objects.filter(user=user).order_by("rank")
+        self.assertEqual(recs.count(), 2)
+        self.assertEqual([recs[0].game_id, recs[1].game_id], [g1.id, g2.id])
+        self.assertTrue(all(rec.generation_version == 2 for rec in recs))
+
+    def test_run_user_refresh_job_success(self) -> None:
+        user = self._create_user()
+        seed = self._create_game(rawg_id=8041, slug="seed-job", name="Seed Job")
+        similar = self._create_game(rawg_id=8042, slug="sim-job", name="Similar Job")
+        InteractionLog.objects.create(
+            user=user,
+            game=seed,
+            type=InteractionLog.ActionType.VIEW,
+            source=InteractionLog.SourceType.DETAIL_PAGE,
+        )
+
+        from apps.recommendations.models import GameSimilarity
+
+        GameSimilarity.objects.create(game=seed, similar_game=similar, score=Decimal("0.8800"))
+        job = RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=user,
+            status=RecommendationJob.Status.PENDING,
+        )
+
+        run_user_refresh_job(job.id)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, RecommendationJob.Status.SUCCESS)
+        self.assertIsNotNone(job.finished_at)
+        self.assertTrue(UserRecommendation.objects.filter(user=user, game=similar).exists())
+
+    def test_run_user_refresh_job_failure_marks_failed(self) -> None:
+        user = self._create_user()
+        job = RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=user,
+            status=RecommendationJob.Status.PENDING,
+        )
+
+        with patch("apps.recommendations.tasks.User.objects.get", side_effect=RuntimeError("boom")):
+            with self.assertRaises(RuntimeError):
+                run_user_refresh_job(job.id)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, RecommendationJob.Status.FAILED)
+        self.assertEqual(job.retry_count, 1)
+        self.assertIn("boom", cast(str, job.error_message))
+
+    def test_process_pending_recommendation_jobs_enqueues_pending_only(self) -> None:
+        user = self._create_user()
+        pending_1 = RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=user,
+            status=RecommendationJob.Status.PENDING,
+        )
+        pending_2 = RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=user,
+            status=RecommendationJob.Status.PENDING,
+        )
+        RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=user,
+            status=RecommendationJob.Status.SUCCESS,
+        )
+
+        with patch("apps.recommendations.tasks.process_user_refresh_job.delay") as mocked_delay:
+            queued = process_pending_recommendation_jobs(limit=20)
+
+        self.assertEqual(queued, 2)
+        mocked_delay.assert_any_call(pending_1.id)
+        mocked_delay.assert_any_call(pending_2.id)

--- a/apps/recommendations/urls.py
+++ b/apps/recommendations/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.recommendations.views import RecommendationListView
+
+urlpatterns = [
+    path("", RecommendationListView.as_view(), name="recommendation-list"),
+]

--- a/apps/recommendations/views.py
+++ b/apps/recommendations/views.py
@@ -1,1 +1,140 @@
-# Create your views here.
+from __future__ import annotations
+
+from typing import cast
+
+from django.db.models import QuerySet
+from drf_spectacular.utils import OpenApiExample, OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework.generics import ListAPIView
+from rest_framework.permissions import IsAuthenticated
+
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.core.serializers.error_serializer import ErrorResponseSerializer
+from apps.core.utils.pagination import PAGINATION_PARAMS, Pagination
+from apps.recommendations.models import UserRecommendation
+from apps.recommendations.serializers import (
+    RecommendationItemSerializer,
+    RecommendationListResponseSerializer,
+    RecommendationQuerySerializer,
+)
+from apps.recommendations.services import RecommendationService
+from apps.users.models import User
+
+
+@extend_schema(
+    tags=["recommendations"],
+    summary="개인화 게임 추천 목록 조회",
+    description=(
+        "개인화 추천 목록을 조회합니다. 추천 데이터가 준비되지 않은 경우 `202`를 반환합니다.\n"
+        "준비되지 않은 상태에서는 `user_refresh` 작업이 자동으로 큐잉됩니다."
+    ),
+    parameters=[
+        OpenApiParameter(
+            "type", type=str, required=False, description="추천 유형", enum=["similarity", "preference", "hybrid"]
+        ),
+        OpenApiParameter("genre", type=str, required=False, description="장르 ID(복수는 콤마 구분)"),
+        OpenApiParameter("tag", type=str, required=False, description="태그 ID(복수는 콤마 구분)"),
+        OpenApiParameter("is_free", type=bool, required=False, description="무료 게임 필터"),
+        OpenApiParameter("is_adult", type=bool, required=False, description="성인 게임 필터"),
+        *PAGINATION_PARAMS,
+    ],
+    responses={
+        200: RecommendationListResponseSerializer,
+        202: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Accepted",
+            examples=[
+                OpenApiExample(
+                    "추천 데이터 준비 중",
+                    value={
+                        "status_code": 202,
+                        "code": "RECOMMENDATION_NOT_READY",
+                        "message": "추천 데이터를 준비중입니다 잠시 후 다시 요청해주세요.",
+                    },
+                )
+            ],
+        ),
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Unauthorized",
+            examples=[
+                OpenApiExample(
+                    "인증 필요",
+                    value={
+                        "status_code": ErrorMessages.UNAUTHORIZED.status_code,
+                        "code": ErrorMessages.UNAUTHORIZED.name,
+                        "message": ErrorMessages.UNAUTHORIZED.message,
+                    },
+                )
+            ],
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Bad Request",
+            examples=[
+                OpenApiExample(
+                    "잘못된 쿼리 파라미터",
+                    value={
+                        "status_code": ErrorMessages.INVALID_QUERY_PARAM.status_code,
+                        "code": ErrorMessages.INVALID_QUERY_PARAM.name,
+                        "message": ErrorMessages.INVALID_QUERY_PARAM.message,
+                    },
+                )
+            ],
+        ),
+    },
+    examples=[
+        OpenApiExample(
+            "요청 예시",
+            value={"type": "similarity", "genre": "1", "tag": "3", "is_free": False, "is_adult": False, "page": 1},
+            request_only=True,
+        ),
+        OpenApiExample(
+            "성공 응답 예시",
+            value={
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "game_id": 652,
+                        "name": "Cyberpunk 2077",
+                        "reason": "hybrid",
+                        "generated_at": "2025-06-17T00:00:00Z",
+                        "rank": 1,
+                        "score": "0.8612",
+                        "tags": ["RPG", "Open World"],
+                        "thumbnail_img_url": "https://media.example.com/cp2077.jpg",
+                        "rawg_rating": "4.70",
+                        "genres": [{"id": 1, "name": "Action"}],
+                    }
+                ],
+            },
+            response_only=True,
+            status_codes=["200"],
+        ),
+    ],
+)
+class RecommendationListView(ListAPIView):  # type: ignore[type-arg]
+    permission_classes = [IsAuthenticated]
+    serializer_class = RecommendationItemSerializer
+    pagination_class = Pagination
+
+    def get_queryset(self) -> QuerySet[UserRecommendation]:
+        query_serializer = RecommendationQuerySerializer(data=self.request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+        data = query_serializer.validated_data
+
+        user = cast(User, self.request.user)
+        if not RecommendationService.is_recommendation_ready(user=user):
+            RecommendationService.enqueue_user_refresh_job_if_needed(user=user)
+            raise CustomAPIException(ErrorMessages.RECOMMENDATION_NOT_READY)
+
+        return RecommendationService.list_recommendations(
+            user=user,
+            rec_type=cast(str | None, data.get("type")),
+            genre_ids=cast(list[int] | None, data.get("genre")),
+            tag_ids=cast(list[int] | None, data.get("tag")),
+            is_adult=cast(bool | None, data.get("is_adult")),
+            is_free=cast(bool | None, data.get("is_free")),
+        )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -247,6 +247,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "games.incremental_sync",
         "schedule": crontab(hour=3, minute=0),
     },
+    "recommendation-process-pending-jobs": {
+        "task": "apps.recommendations.tasks.process_pending_recommendation_jobs",
+        "schedule": timedelta(seconds=30),
+    },
 }
 
 CELERY_TASK_ACKS_LATE = True  # 실행 완료 후 ack → 워커 재시작 시 재실행 보장

--- a/config/urls.py
+++ b/config/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("api/schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
     path("api/v1/preferences/", include("apps.preferences.urls")),
     path("api/v1/interactions/", include("apps.interactions.urls")),
+    path("api/v1/recommendations/", include("apps.recommendations.urls")),
     path("admin/", admin.site.urls),
     path("api/v1/", include("apps.users.urls")),
     path("api/v1/games/", include("apps.games.urls.games")),


### PR DESCRIPTION
## ✅ PR 요약
- GET /api/v1/recommendations/ API를 추가
- 추천 미준비 상태에서는 `202 RECOMMENDATION_NOT_READY`를 반환
- NOT_READY 시 user_refresh 작업을 자동 큐잉하도록 연결

## 📄 상세 내용
- [x]`type/genre/tag/is_adult` 필터와 페이지네이션을 구현했습니다. (`is_free`는 현재 스키마 한계로 파라미터만 수용)
- [x] Celery task/beat를 추가해 pending 추천 job 자동 처리 흐름을 구성했습니다.
-`is_free`는 현재 게임 스키마에 판별 컬럼이 없어 파라미터 수용만 하고 필터는 미적용입니다.  관련 데이터 모델 확정 시 서비스 레이어에서 바로 필터 연결 가능합니다.


## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] 빌드/린트가 통과합니다. (가능한 경우)
DB/worker 연동 포함 통합 검증은 운영/배포 환경에서 추가 확인 예정입니다.

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [] 관련 이슈/작업 링크를 남겼습니다. (선택)
