### PR TITLE
[Feature/recommendations/status] 추천 상태 API 추가 및 작업 중복 실행 방지

### DIFF
--- a/apps/recommendations/serializers.py
+++ b/apps/recommendations/serializers.py
@@ -83,3 +83,10 @@ class RecommendationListResponseSerializer(serializers.Serializer):  # type: ign
     next = serializers.CharField(allow_null=True)
     previous = serializers.CharField(allow_null=True)
     results = RecommendationItemSerializer(many=True)
+
+
+class RecommendationStatusResponseSerializer(serializers.Serializer[dict[str, Any]]):
+    status = serializers.ChoiceField(choices=["pending", "success", "failed"])
+    generation = serializers.IntegerField(allow_null=True)
+    generated_at = serializers.DateTimeField(allow_null=True)
+    expires_at = serializers.DateTimeField(allow_null=True)

--- a/apps/recommendations/services.py
+++ b/apps/recommendations/services.py
@@ -1,9 +1,50 @@
 from __future__ import annotations
 
+from datetime import datetime
+from typing import TypedDict
+
 from django.db.models import QuerySet
 
 from apps.recommendations.models import RecommendationJob, UserRecommendation
 from apps.users.models import User
+
+
+class RecommendationStatusResult(TypedDict):
+    status: str
+    generation: int | None
+    generated_at: datetime | None
+    expires_at: datetime | None
+
+
+class RecommendationStatusService:
+    @staticmethod
+    def get_status(*, user: User) -> RecommendationStatusResult:
+        latest_job = RecommendationService._get_latest_user_refresh_job(user=user)
+        latest_recommendation = (
+            UserRecommendation.objects.filter(user=user)
+            .order_by("-generation_version", "-generated_at")
+            .first()
+        )
+
+        has_recommendation = latest_recommendation is not None
+
+        if latest_job is None:
+            status = "success" if has_recommendation else "pending"
+        elif latest_job.status in (RecommendationJob.Status.PENDING, RecommendationJob.Status.RUNNING):
+            status = "pending"
+        elif latest_job.status == RecommendationJob.Status.FAILED:
+            status = "failed"
+        elif latest_job.status == RecommendationJob.Status.SUCCESS:
+            status = "success" if has_recommendation else "pending"
+        else:
+            status = "pending"
+
+        return {
+            "status": status,
+            "generation": latest_recommendation.generation_version if latest_recommendation else None,
+            "generated_at": latest_recommendation.generated_at if latest_recommendation else None,
+            "expires_at": latest_recommendation.expires_at if latest_recommendation else None,
+        }
 
 
 class RecommendationService:

--- a/apps/recommendations/services.py
+++ b/apps/recommendations/services.py
@@ -19,23 +19,19 @@ class RecommendationStatusResult(TypedDict):
 class RecommendationStatusService:
     @staticmethod
     def get_status(*, user: User) -> RecommendationStatusResult:
-        latest_job = RecommendationService._get_latest_user_refresh_job(user=user)
+        latest_job = RecommendationService.get_latest_user_refresh_job(user=user)
         latest_recommendation = (
-            UserRecommendation.objects.filter(user=user)
-            .order_by("-generation_version", "-generated_at")
-            .first()
+            UserRecommendation.objects.filter(user=user).order_by("-generation_version", "-generated_at").first()
         )
 
         has_recommendation = latest_recommendation is not None
 
-        if latest_job is None:
+        if latest_job is None or latest_job.status == RecommendationJob.Status.SUCCESS:
             status = "success" if has_recommendation else "pending"
         elif latest_job.status in (RecommendationJob.Status.PENDING, RecommendationJob.Status.RUNNING):
             status = "pending"
         elif latest_job.status == RecommendationJob.Status.FAILED:
             status = "failed"
-        elif latest_job.status == RecommendationJob.Status.SUCCESS:
-            status = "success" if has_recommendation else "pending"
         else:
             status = "pending"
 
@@ -49,7 +45,7 @@ class RecommendationStatusService:
 
 class RecommendationService:
     @staticmethod
-    def _get_latest_user_refresh_job(*, user: User) -> RecommendationJob | None:
+    def get_latest_user_refresh_job(*, user: User) -> RecommendationJob | None:
         return (
             RecommendationJob.objects.filter(
                 target_user=user,
@@ -61,7 +57,7 @@ class RecommendationService:
 
     @staticmethod
     def is_recommendation_ready(*, user: User) -> bool:
-        latest_user_refresh_job = RecommendationService._get_latest_user_refresh_job(user=user)
+        latest_user_refresh_job = RecommendationService.get_latest_user_refresh_job(user=user)
         if latest_user_refresh_job is not None and latest_user_refresh_job.status in {
             RecommendationJob.Status.PENDING,
             RecommendationJob.Status.RUNNING,
@@ -105,7 +101,7 @@ class RecommendationService:
 
     @staticmethod
     def enqueue_user_refresh_job_if_needed(*, user: User) -> RecommendationJob:
-        latest_user_refresh_job = RecommendationService._get_latest_user_refresh_job(user=user)
+        latest_user_refresh_job = RecommendationService.get_latest_user_refresh_job(user=user)
         if latest_user_refresh_job is not None and latest_user_refresh_job.status in {
             RecommendationJob.Status.PENDING,
             RecommendationJob.Status.RUNNING,

--- a/apps/recommendations/tasks.py
+++ b/apps/recommendations/tasks.py
@@ -99,7 +99,8 @@ def run_user_refresh_job(job_id: int) -> None:
         )
         if job is None or job.target_user_id is None:
             return
-        if job.status not in {RecommendationJob.Status.PENDING, RecommendationJob.Status.RUNNING}:
+        # Duplicate queued tasks can exist; only the first PENDING->RUNNING transition should execute.
+        if job.status != RecommendationJob.Status.PENDING:
             return
         target_user_id = job.target_user_id
         current_retry_count = job.retry_count

--- a/apps/recommendations/tests.py
+++ b/apps/recommendations/tests.py
@@ -200,6 +200,123 @@ class RecommendationListAPITestCase(TestCase):
         self.assertEqual(payload["code"], "INVALID_QUERY_PARAM")
 
 
+class RecommendationStatusAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/recommendations/status/"
+        self.user = User.objects.create_user(
+            email="status-user@ex.com",
+            nickname="status-user",
+            birth_date=date(1991, 1, 1),
+            password="pw",
+        )
+
+    def _create_game(self, *, rawg_id: int, slug: str, name: str) -> Game:
+        return Game.objects.create(
+            rawg_id=rawg_id,
+            slug=slug,
+            name=name,
+            thumbnail_img_url="https://example.com/thumb.jpg",
+            website="https://example.com",
+            rawg_rating=Decimal("4.10"),
+            is_visible=True,
+        )
+
+    def _create_recommendation(self, *, generation: int) -> UserRecommendation:
+        game = self._create_game(rawg_id=9000 + generation, slug=f"status-{generation}", name=f"Status {generation}")
+        now = timezone.now()
+        return UserRecommendation.objects.create(
+            user=self.user,
+            game=game,
+            generation_version=generation,
+            score=Decimal("0.9000"),
+            rank=1,
+            reason=UserRecommendation.ReasonType.SIMILARITY,
+            generated_at=now,
+            expires_at=now + timedelta(days=7),
+        )
+
+    def test_status_unauthorized(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_status_pending_when_no_job_and_no_recommendation(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data["status"], "pending")
+        self.assertIsNone(data["generation"])
+        self.assertIsNone(data["generated_at"])
+        self.assertIsNone(data["expires_at"])
+
+    def test_status_pending_when_job_running(self) -> None:
+        rec = self._create_recommendation(generation=2)
+        RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=self.user,
+            status=RecommendationJob.Status.RUNNING,
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data["status"], "pending")
+        self.assertEqual(data["generation"], rec.generation_version)
+
+    def test_status_success_when_job_success_and_recommendation_exists(self) -> None:
+        rec = self._create_recommendation(generation=3)
+        RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=self.user,
+            status=RecommendationJob.Status.SUCCESS,
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["generation"], rec.generation_version)
+
+    def test_status_pending_when_job_success_but_no_recommendation(self) -> None:
+        RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=self.user,
+            status=RecommendationJob.Status.SUCCESS,
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data["status"], "pending")
+        self.assertIsNone(data["generation"])
+
+    def test_status_failed_when_job_failed(self) -> None:
+        rec = self._create_recommendation(generation=4)
+        RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=self.user,
+            status=RecommendationJob.Status.FAILED,
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data["status"], "failed")
+        self.assertEqual(data["generation"], rec.generation_version)
+
+
 class RecommendationTaskTestCase(TestCase):
     def _create_user(self) -> User:
         return User.objects.create_user(
@@ -364,6 +481,21 @@ class RecommendationTaskTestCase(TestCase):
         self.assertEqual(job.status, RecommendationJob.Status.FAILED)
         self.assertEqual(job.retry_count, 1)
         self.assertIn("boom", cast(str, job.error_message))
+
+    def test_run_user_refresh_job_skips_when_job_already_running(self) -> None:
+        user = self._create_user()
+        job = RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=user,
+            status=RecommendationJob.Status.RUNNING,
+            started_at=timezone.now(),
+        )
+
+        run_user_refresh_job(job.id)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, RecommendationJob.Status.RUNNING)
+        self.assertFalse(UserRecommendation.objects.filter(user=user).exists())
 
     def test_process_pending_recommendation_jobs_enqueues_pending_only(self) -> None:
         user = self._create_user()

--- a/apps/recommendations/urls.py
+++ b/apps/recommendations/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from apps.recommendations.views import RecommendationListView
+from apps.recommendations.views import RecommendationListView, RecommendationStatusView
 
 urlpatterns = [
     path("", RecommendationListView.as_view(), name="recommendation-list"),
+    path("status/", RecommendationStatusView.as_view(), name="recommendation-status"),
 ]

--- a/apps/recommendations/views.py
+++ b/apps/recommendations/views.py
@@ -4,8 +4,12 @@ from typing import cast
 
 from django.db.models import QuerySet
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
@@ -16,8 +20,9 @@ from apps.recommendations.serializers import (
     RecommendationItemSerializer,
     RecommendationListResponseSerializer,
     RecommendationQuerySerializer,
+    RecommendationStatusResponseSerializer,
 )
-from apps.recommendations.services import RecommendationService
+from apps.recommendations.services import RecommendationService, RecommendationStatusService
 from apps.users.models import User
 
 
@@ -138,3 +143,61 @@ class RecommendationListView(ListAPIView):  # type: ignore[type-arg]
             is_adult=cast(bool | None, data.get("is_adult")),
             is_free=cast(bool | None, data.get("is_free")),
         )
+
+
+@extend_schema(
+    tags=["recommendations"],
+    summary="추천 생성 상태 조회",
+    description=(
+        "추천 생성 상태를 조회합니다. "
+        "상태 값은 최신 user_refresh 작업 상태와 추천 row 존재 여부를 함께 반영합니다. "
+        "추천 row가 없으면 generation/generated_at/expires_at는 null입니다."
+    ),
+    responses={
+        200: OpenApiResponse(
+            response=RecommendationStatusResponseSerializer,
+            description="추천 상태 조회 성공",
+            examples=[
+                OpenApiExample(
+                    "대기 상태",
+                    value={
+                        "status": "pending",
+                        "generation": None,
+                        "generated_at": None,
+                        "expires_at": None,
+                    },
+                ),
+                OpenApiExample(
+                    "생성 완료 상태",
+                    value={
+                        "status": "success",
+                        "generation": 3,
+                        "generated_at": "2026-03-08T09:00:00Z",
+                        "expires_at": "2026-03-15T09:00:00Z",
+                    },
+                ),
+            ],
+        ),
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Unauthorized",
+            examples=[
+                OpenApiExample(
+                    "인증 필요",
+                    value={
+                        "status_code": ErrorMessages.UNAUTHORIZED.status_code,
+                        "code": ErrorMessages.UNAUTHORIZED.name,
+                        "message": ErrorMessages.UNAUTHORIZED.message,
+                    },
+                )
+            ],
+        ),
+    },
+)
+class RecommendationStatusView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        user = cast(User, request.user)
+        result = RecommendationStatusService.get_status(user=user)
+        return Response(result, status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 추천 생성 상태 조회 API(GET /api/v1/recommendations/status/)를 추가

## 📄 상세 내용
- [x] 상태 매핑 규칙(pending/success/failed)을 job + 추천 row 기준으로 반영
- [x] Celery 중복 실행 방지 관련 테스트(RUNNING 상태 skip)를 추가
- [x] RecommendationStatusView/RecommendationStatusService/응답 serializer를 추가
- [x] run_user_refresh_job에서 PENDING 상태만 실행하도록 변경해 중복 처리 재진입을 방지

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] 빌드/린트가 통과합니다. (가능한 경우)

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
