### PR TITLE
[Feature/admin/recommendation jobs run] 추천 작업 수동 실행 API 추가

### DIFF
--- a/apps/recommendations/serializers.py
+++ b/apps/recommendations/serializers.py
@@ -6,7 +6,8 @@ from rest_framework import serializers
 
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
-from apps.recommendations.models import UserRecommendation
+from apps.recommendations.models import RecommendationJob, UserRecommendation
+from apps.users.models import User
 
 
 class RecommendationQuerySerializer(serializers.Serializer[dict[str, Any]]):
@@ -132,4 +133,33 @@ class RecommendationJobDetailResponseSerializer(serializers.Serializer):  # type
     target_user = serializers.IntegerField(source="target_user_id", allow_null=True)
     error_message = serializers.CharField(allow_null=True)
     started_at = serializers.DateTimeField(allow_null=True)
+    created_at = serializers.DateTimeField()
+
+
+class RecommendationJobRunRequestSerializer(serializers.Serializer[dict[str, Any]]):
+    job_type = serializers.CharField(required=False)
+    target_user = serializers.IntegerField(required=False, allow_null=True)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        job_type = attrs.get("job_type")
+        if not job_type:
+            raise CustomAPIException(ErrorMessages.JOB_TYPE_MISSING)
+
+        if job_type not in set(RecommendationJob.JobType.values):
+            raise CustomAPIException(ErrorMessages.VALIDATION_ERROR)
+
+        target_user = attrs.get("target_user")
+        if target_user is not None and not User.objects.filter(id=target_user).exists():
+            raise CustomAPIException(ErrorMessages.VALIDATION_ERROR)
+
+        if job_type == RecommendationJob.JobType.SIMILARITY_REBUILD and target_user is not None:
+            raise CustomAPIException(ErrorMessages.VALIDATION_ERROR)
+
+        return attrs
+
+
+class RecommendationJobRunResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    id = serializers.IntegerField()
+    type = serializers.CharField(source="job_type")
+    status = serializers.CharField()
     created_at = serializers.DateTimeField()

--- a/apps/recommendations/services.py
+++ b/apps/recommendations/services.py
@@ -5,6 +5,8 @@ from typing import TypedDict
 
 from django.db.models import QuerySet
 
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
 from apps.recommendations.models import RecommendationJob, UserRecommendation
 from apps.users.models import User
 
@@ -134,3 +136,23 @@ class RecommendationAdminService:
     @staticmethod
     def get_recommendation_job(*, job_id: int) -> RecommendationJob | None:
         return RecommendationJob.objects.select_related("target_user").filter(id=job_id).first()
+
+    @staticmethod
+    def create_recommendation_job(
+        *,
+        job_type: str,
+        target_user_id: int | None,
+    ) -> RecommendationJob:
+        has_running_job = RecommendationJob.objects.filter(
+            job_type=job_type,
+            target_user_id=target_user_id,
+            status__in=[RecommendationJob.Status.PENDING, RecommendationJob.Status.RUNNING],
+        ).exists()
+        if has_running_job:
+            raise CustomAPIException(ErrorMessages.JOB_ALREADY_RUNNING)
+
+        return RecommendationJob.objects.create(
+            job_type=job_type,
+            target_user_id=target_user_id,
+            status=RecommendationJob.Status.PENDING,
+        )

--- a/apps/recommendations/tests.py
+++ b/apps/recommendations/tests.py
@@ -733,3 +733,108 @@ class AdminRecommendationJobDetailAPITestCase(TestCase):
         self.assertEqual(payload["error_message"], "Connection timeout")
         self.assertIsNotNone(payload["started_at"])
         self.assertIsNotNone(payload["created_at"])
+
+
+class AdminRecommendationJobRunAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/admin/recommendation-jobs/run/"
+        self.admin_user = User.objects.create_user(
+            email="admin-run@ex.com",
+            nickname="admin-run",
+            birth_date=date(1990, 1, 1),
+            password="pw",
+            is_staff=True,
+        )
+        self.normal_user = User.objects.create_user(
+            email="normal-run@ex.com",
+            nickname="normal-run",
+            birth_date=date(1994, 1, 1),
+            password="pw",
+        )
+
+    def test_admin_recommendation_job_run_unauthorized(self) -> None:
+        response = self.client.post(self.url, data={"job_type": "user_refresh"}, format="json")
+        self.assertEqual(response.status_code, 401)
+
+    def test_admin_recommendation_job_run_forbidden_for_non_admin(self) -> None:
+        self.client.force_authenticate(user=self.normal_user)
+        response = self.client.post(self.url, data={"job_type": "user_refresh"}, format="json")
+
+        self.assertEqual(response.status_code, 403)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data["code"], ErrorMessages.FORBIDDEN.name)
+
+    def test_admin_recommendation_job_run_bad_request_when_job_type_missing(self) -> None:
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.post(self.url, data={}, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data["code"], ErrorMessages.JOB_TYPE_MISSING.name)
+
+    def test_admin_recommendation_job_run_conflict_when_pending_exists(self) -> None:
+        RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=None,
+            status=RecommendationJob.Status.PENDING,
+        )
+
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.post(self.url, data={"job_type": "user_refresh"}, format="json")
+
+        self.assertEqual(response.status_code, 409)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data["code"], ErrorMessages.JOB_ALREADY_RUNNING.name)
+
+    def test_admin_recommendation_job_run_success(self) -> None:
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.post(
+            self.url,
+            data={"job_type": "user_refresh", "target_user": None},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        payload = cast(dict[str, Any], response.data)
+        self.assertEqual(payload["type"], RecommendationJob.JobType.USER_REFRESH)
+        self.assertEqual(payload["status"], RecommendationJob.Status.PENDING)
+        self.assertIsNotNone(payload["created_at"])
+
+    def test_admin_recommendation_job_run_enqueues_when_target_user_exists(self) -> None:
+        target_user = User.objects.create_user(
+            email="target-run@ex.com",
+            nickname="target-run",
+            birth_date=date(1995, 1, 1),
+            password="pw",
+        )
+        self.client.force_authenticate(user=self.admin_user)
+
+        with patch("apps.recommendations.views_admin.process_user_refresh_job.delay") as mocked_delay:
+            response = self.client.post(
+                self.url,
+                data={"job_type": "user_refresh", "target_user": target_user.id},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 201)
+        job_id = cast(dict[str, Any], response.data)["id"]
+        mocked_delay.assert_called_once_with(job_id)
+
+    def test_admin_recommendation_job_run_similarity_rebuild_rejects_target_user(self) -> None:
+        target_user = User.objects.create_user(
+            email="target-run2@ex.com",
+            nickname="target-run2",
+            birth_date=date(1996, 1, 1),
+            password="pw",
+        )
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.post(
+            self.url,
+            data={"job_type": "similarity_rebuild", "target_user": target_user.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)

--- a/apps/recommendations/urls_admin.py
+++ b/apps/recommendations/urls_admin.py
@@ -1,8 +1,13 @@
 from django.urls import path
 
-from apps.recommendations.views_admin import AdminRecommendationJobDetailView, AdminRecommendationJobListView
+from apps.recommendations.views_admin import (
+    AdminRecommendationJobDetailView,
+    AdminRecommendationJobListView,
+    AdminRecommendationJobRunView,
+)
 
 urlpatterns = [
     path("", AdminRecommendationJobListView.as_view(), name="admin-recommendation-job-list"),
+    path("run/", AdminRecommendationJobRunView.as_view(), name="admin-recommendation-job-run"),
     path("<int:job_id>/", AdminRecommendationJobDetailView.as_view(), name="admin-recommendation-job-detail"),
 ]

--- a/apps/recommendations/views_admin.py
+++ b/apps/recommendations/views_admin.py
@@ -21,8 +21,11 @@ from apps.recommendations.serializers import (
     RecommendationJobItemSerializer,
     RecommendationJobListQuerySerializer,
     RecommendationJobListResponseSerializer,
+    RecommendationJobRunRequestSerializer,
+    RecommendationJobRunResponseSerializer,
 )
 from apps.recommendations.services import RecommendationAdminService
+from apps.recommendations.tasks import process_user_refresh_job
 from apps.users.models import User
 
 
@@ -220,3 +223,109 @@ class AdminRecommendationJobDetailView(APIView):
 
         serializer = RecommendationJobDetailResponseSerializer(job)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@extend_schema(
+    tags=["admin"],
+    summary="추천 작업 수동 실행",
+    description="관리자 권한으로 추천 작업을 수동 실행합니다.",
+    request=RecommendationJobRunRequestSerializer,
+    responses={
+        201: RecommendationJobRunResponseSerializer,
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Bad Request",
+            examples=[
+                OpenApiExample(
+                    "job_type 누락",
+                    value={
+                        "status_code": ErrorMessages.JOB_TYPE_MISSING.status_code,
+                        "code": ErrorMessages.JOB_TYPE_MISSING.name,
+                        "message": ErrorMessages.JOB_TYPE_MISSING.message,
+                    },
+                )
+            ],
+        ),
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Unauthorized",
+            examples=[
+                OpenApiExample(
+                    "인증 필요",
+                    value={
+                        "status_code": ErrorMessages.UNAUTHORIZED.status_code,
+                        "code": ErrorMessages.UNAUTHORIZED.name,
+                        "message": ErrorMessages.UNAUTHORIZED.message,
+                    },
+                )
+            ],
+        ),
+        403: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Forbidden",
+            examples=[
+                OpenApiExample(
+                    "관리자 권한 필요",
+                    value={
+                        "status_code": ErrorMessages.FORBIDDEN.status_code,
+                        "code": ErrorMessages.FORBIDDEN.name,
+                        "message": ErrorMessages.FORBIDDEN.message,
+                    },
+                )
+            ],
+        ),
+        409: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Conflict",
+            examples=[
+                OpenApiExample(
+                    "이미 실행 중인 작업",
+                    value={
+                        "status_code": ErrorMessages.JOB_ALREADY_RUNNING.status_code,
+                        "code": ErrorMessages.JOB_ALREADY_RUNNING.name,
+                        "message": ErrorMessages.JOB_ALREADY_RUNNING.message,
+                    },
+                )
+            ],
+        ),
+    },
+    examples=[
+        OpenApiExample(
+            "요청 예시",
+            value={"job_type": "user_refresh", "target_user": None},
+            request_only=True,
+        ),
+        OpenApiExample(
+            "응답 예시",
+            value={
+                "id": 11,
+                "type": "user_refresh",
+                "status": "pending",
+                "created_at": "2025-08-01T12:00:00Z",
+            },
+            response_only=True,
+            status_codes=["201"],
+        ),
+    ],
+)
+class AdminRecommendationJobRunView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request) -> Response:
+        user = cast(User, request.user)
+        if not user.is_staff:
+            raise CustomAPIException(ErrorMessages.FORBIDDEN)
+
+        req_serializer = RecommendationJobRunRequestSerializer(data=request.data)
+        req_serializer.is_valid(raise_exception=True)
+        data = req_serializer.validated_data
+
+        job = RecommendationAdminService.create_recommendation_job(
+            job_type=cast(str, data["job_type"]),
+            target_user_id=cast(int | None, data.get("target_user")),
+        )
+        if job.job_type == RecommendationJob.JobType.USER_REFRESH and job.target_user_id is not None:
+            process_user_refresh_job.delay(job.id)
+
+        serializer = RecommendationJobRunResponseSerializer(job)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## ✅ PR 요약
- POST /api/v1/admin/recommendation-jobs/run/ 관리자 전용 추천 작업 수동 실행 API 추가

## 📄 상세 내용
- [x] user_refresh + target_user 조건에서 Celery 작업 enqueue를 연결
- [x] services.py에 job 생성 및 중복 실행 체크 로직을 추가, serializers.py에 run 요청/응답 serializer를 추가
- [x] urls_admin.py 에 run/ 라우트를 연결

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] 빌드/린트가 통과합니다. (가능한 경우)

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
