### PR TITLE
[Feature/admin/interaction weight rules list] 행동 가중치 목록 조회 API 추가

### DIFF
--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -83,3 +83,15 @@ class InteractionStoreClickLogResponseSerializer(serializers.Serializer):  # typ
     id = serializers.IntegerField()
     type = serializers.CharField()
     logged_at = serializers.DateTimeField(source="created_at")
+
+
+class InteractionWeightRuleItemSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    interaction_type = serializers.CharField()
+    base_weight = serializers.DecimalField(max_digits=4, decimal_places=2)
+    cooldown_seconds = serializers.IntegerField()
+    repeat_decay = serializers.DecimalField(max_digits=4, decimal_places=3)
+    updated_at = serializers.DateTimeField()
+
+
+class InteractionWeightRuleListResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    results = InteractionWeightRuleItemSerializer(many=True)

--- a/apps/interactions/services/__init__.py
+++ b/apps/interactions/services/__init__.py
@@ -1,7 +1,13 @@
+from .admin_weight_rule_service import InteractionAdminRuleService
 from .view_log_service import (
     record_search_interaction,
     record_store_click_interaction,
     record_view_interaction,
 )
 
-__all__ = ["record_view_interaction", "record_search_interaction", "record_store_click_interaction"]
+__all__ = [
+    "InteractionAdminRuleService",
+    "record_view_interaction",
+    "record_search_interaction",
+    "record_store_click_interaction",
+]

--- a/apps/interactions/services/admin_weight_rule_service.py
+++ b/apps/interactions/services/admin_weight_rule_service.py
@@ -1,0 +1,27 @@
+from django.db.models import Case, IntegerField, QuerySet, When
+
+from apps.interactions.models import InteractionWeightRule
+
+
+class InteractionAdminRuleService:
+    @staticmethod
+    def list_weight_rules() -> QuerySet[InteractionWeightRule]:
+        ordered_types = [
+            InteractionWeightRule.ActionType.VIEW,
+            InteractionWeightRule.ActionType.SEARCH,
+            InteractionWeightRule.ActionType.SAVED_ADD,
+            InteractionWeightRule.ActionType.SAVED_REMOVE,
+            InteractionWeightRule.ActionType.LIKE,
+            InteractionWeightRule.ActionType.DISLIKE,
+            InteractionWeightRule.ActionType.PREFERENCE_SET,
+            InteractionWeightRule.ActionType.STORE_CLICK,
+        ]
+        order_case = Case(
+            *[
+                When(interaction_type=interaction_type, then=index)
+                for index, interaction_type in enumerate(ordered_types)
+            ],
+            default=len(ordered_types),
+            output_field=IntegerField(),
+        )
+        return InteractionWeightRule.objects.all().order_by(order_case)

--- a/apps/interactions/tests.py
+++ b/apps/interactions/tests.py
@@ -809,3 +809,73 @@ class InteractionStoreClickLogCreateAPITestCase(TestCase):
         second_log = InteractionLog.objects.get(id=second_id)
         self.assertIsNotNone(second_log.weight)
         self.assertEqual(float(cast(Any, second_log.weight)), 0.108)  # 0.1 * 1.2 * 0.9^1
+
+
+class AdminInteractionWeightRuleListAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/admin/interaction-weight-rules/"
+
+    def _create_user(self, *, is_staff: bool = False) -> User:
+        return User.objects.create_user(
+            email=f"admin-rule-{is_staff}@ex.com",
+            nickname=f"admin-rule-{is_staff}",
+            birth_date=date(1991, 1, 1),
+            password="pw",
+            is_staff=is_staff,
+        )
+
+    def test_admin_interaction_weight_rule_list_unauthorized(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_admin_interaction_weight_rule_list_forbidden_for_non_staff(self) -> None:
+        user = self._create_user(is_staff=False)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "FORBIDDEN")
+
+    def test_admin_interaction_weight_rule_list_success(self) -> None:
+        admin = self._create_user(is_staff=True)
+        self.client.force_authenticate(user=admin)
+
+        InteractionWeightRule.objects.create(
+            interaction_type=InteractionWeightRule.ActionType.STORE_CLICK,
+            base_weight=0.70,
+            cooldown_seconds=70,
+            repeat_decay=0.700,
+            is_active=True,
+        )
+        InteractionWeightRule.objects.create(
+            interaction_type=InteractionWeightRule.ActionType.VIEW,
+            base_weight=1.00,
+            cooldown_seconds=60,
+            repeat_decay=0.800,
+            is_active=True,
+        )
+        InteractionWeightRule.objects.create(
+            interaction_type=InteractionWeightRule.ActionType.SEARCH,
+            base_weight=0.90,
+            cooldown_seconds=30,
+            repeat_decay=0.750,
+            is_active=True,
+        )
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        data = cast(dict[str, Any], response.data)
+        self.assertIn("results", data)
+        results = cast(list[dict[str, Any]], data["results"])
+        self.assertEqual([item["interaction_type"] for item in results], ["view", "search", "store_click"])
+
+        first = results[0]
+        self.assertEqual(first["base_weight"], "1.00")
+        self.assertEqual(first["cooldown_seconds"], 60)
+        self.assertEqual(first["repeat_decay"], "0.800")
+        self.assertIn("updated_at", first)

--- a/apps/interactions/urls_admin.py
+++ b/apps/interactions/urls_admin.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.interactions.views_admin import AdminInteractionWeightRuleListView
+
+urlpatterns = [
+    path("", AdminInteractionWeightRuleListView.as_view(), name="admin-interaction-weight-rule-list"),
+]

--- a/apps/interactions/views_admin.py
+++ b/apps/interactions/views_admin.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import cast
+
+from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.core.serializers.error_serializer import ErrorResponseSerializer
+from apps.interactions.serializers import (
+    InteractionWeightRuleItemSerializer,
+    InteractionWeightRuleListResponseSerializer,
+)
+from apps.interactions.services import InteractionAdminRuleService
+from apps.users.models import User
+
+
+@extend_schema(
+    tags=["admin"],
+    summary="행동 가중치 목록 조회",
+    description="관리자 권한으로 행동 가중치 규칙 목록을 조회합니다.",
+    responses={
+        200: InteractionWeightRuleListResponseSerializer,
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Unauthorized",
+            examples=[
+                OpenApiExample(
+                    "인증 필요",
+                    value={
+                        "status_code": ErrorMessages.UNAUTHORIZED.status_code,
+                        "code": ErrorMessages.UNAUTHORIZED.name,
+                        "message": ErrorMessages.UNAUTHORIZED.message,
+                    },
+                )
+            ],
+        ),
+        403: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Forbidden",
+            examples=[
+                OpenApiExample(
+                    "관리자 권한 필요",
+                    value={
+                        "status_code": ErrorMessages.FORBIDDEN.status_code,
+                        "code": ErrorMessages.FORBIDDEN.name,
+                        "message": ErrorMessages.FORBIDDEN.message,
+                    },
+                )
+            ],
+        ),
+    },
+    examples=[
+        OpenApiExample(
+            "응답 예시",
+            value={
+                "results": [
+                    {
+                        "interaction_type": "view",
+                        "base_weight": "1.00",
+                        "cooldown_seconds": 60,
+                        "repeat_decay": "0.800",
+                        "updated_at": "2025-01-01T00:00:00Z",
+                    }
+                ]
+            },
+            response_only=True,
+            status_codes=["200"],
+        )
+    ],
+)
+class AdminInteractionWeightRuleListView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        user = cast(User, request.user)
+        if not user.is_staff:
+            raise CustomAPIException(ErrorMessages.FORBIDDEN)
+
+        rules = InteractionAdminRuleService.list_weight_rules()
+        serializer = InteractionWeightRuleItemSerializer(rules, many=True)
+        return Response({"results": serializer.data}, status=status.HTTP_200_OK)

--- a/config/urls.py
+++ b/config/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("api/schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
     path("api/v1/preferences/", include("apps.preferences.urls")),
     path("api/v1/interactions/", include("apps.interactions.urls")),
+    path("api/v1/admin/interaction-weight-rules/", include("apps.interactions.urls_admin")),
     path("api/v1/recommendations/", include("apps.recommendations.urls")),
     path("api/v1/admin/recommendation-jobs/", include("apps.recommendations.urls_admin")),
     path("admin/", admin.site.urls),


### PR DESCRIPTION
## ✅ PR 요약
- GET /api/v1/admin/interaction-weight-rules/ 행동 가중치 목록 조회 API 추가

## 📄 상세 내용
- [x] 행동 가중치 목록 응답 serializer/service/view/url 구성
- [x] 조회 로직은 서비스 레이어로 분리하여(`InteractionAdminRuleService`) 유지보수성을 높였습니다
- [x] 권한 정책은 `IsAuthenticated` + `is_staff` 검증으로 적용했고, 비관리자는 `403 FORBIDDEN`을 반환합니다.

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] 빌드/린트가 통과합니다. (가능한 경우)

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
