### PR TITLE
[Feature/users/verify-password]비밀번호 재확인 API 추가

### DIFF
--- a/apps/core/exceptions/exception_message.py
+++ b/apps/core/exceptions/exception_message.py
@@ -42,6 +42,7 @@ class ErrorMessages(Enum):
     # 401 Unauthorized
     UNAUTHORIZED = (401, "인증이 필요합니다.")
     INVALID_CREDENTIALS = (401, "이메일 또는 비밀번호가 올바르지 않습니다.")
+    INVALID_PASSWORD = (401, "비밀번호가 올바르지 않습니다.")
     ACCOUNT_DEACTIVATED = (401, "비활성화된 계정입니다.")
     TOKEN_EXPIRED = (401, "액세스 토큰이 만료되었습니다.")
     INVALID_REFRESH_TOKEN = (401, "유효하지 않은 리프레시 토큰입니다.")

--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -34,3 +34,7 @@ class UserMeUpdateResponseSerializer(serializers.ModelSerializer[User]):
 class UserMeUpdateRequestSerializer(serializers.Serializer[dict[str, object]]):
     nickname = serializers.CharField(required=False, max_length=30)
     birth_date = serializers.DateField(required=False)
+
+
+class UserPasswordVerifyRequestSerializer(serializers.Serializer[dict[str, object]]):
+    password = serializers.CharField(write_only=True)

--- a/apps/users/services/__init__.py
+++ b/apps/users/services/__init__.py
@@ -9,7 +9,7 @@ from .auth_service import (
     signup_user,
 )
 from .social_auth_service import build_kakao_login_url, handle_kakao_callback
-from .user_me_service import get_user_me, update_user_me
+from .user_me_service import get_user_me, update_user_me, verify_user_password
 
 __all__ = [
     "authenticate_user",
@@ -22,6 +22,7 @@ __all__ = [
     "send_email_code",
     "signup_user",
     "update_user_me",
+    "verify_user_password",
     "build_kakao_login_url",
     "handle_kakao_callback",
 ]

--- a/apps/users/services/user_me_service.py
+++ b/apps/users/services/user_me_service.py
@@ -5,6 +5,7 @@ from datetime import date
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
+from apps.users.services.auth_service import get_active_user_or_deactivated
 
 
 def get_user_me(user: User) -> User:
@@ -32,3 +33,14 @@ def update_user_me(user: User, *, nickname: str | None = None, birth_date: date 
         user.save(update_fields=update_fields + ["updated_at"])
 
     return user
+
+
+def verify_user_password(user: User, *, password: str) -> None:
+    user = get_user_me(user)
+    get_active_user_or_deactivated(user)
+
+    if user.social_accounts.exists() and not user.has_usable_password():
+        raise CustomAPIException(ErrorMessages.SOCIAL_USER_ONLY)
+
+    if not user.check_password(password):
+        raise CustomAPIException(ErrorMessages.INVALID_PASSWORD)

--- a/apps/users/tests/test_verify_password.py
+++ b/apps/users/tests/test_verify_password.py
@@ -1,0 +1,73 @@
+import datetime
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.users.models.social_user import SocialUser
+
+
+class UserPasswordVerifyAPITest(TestCase):
+    def setUp(self) -> None:
+        self.client: APIClient = APIClient()
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            email="verify@example.com",
+            password="Passw0rd!",
+            nickname="verifyuser",
+            birth_date=datetime.date(1999, 1, 1),
+        )
+        self.url = "/api/v1/users/me/verify-password/"
+
+    def test_verify_password_returns_200_when_password_matches(self) -> None:
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            self.url,
+            {"password": "Passw0rd!"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["message"], "비밀번호가 확인되었습니다.")
+
+    def test_verify_password_returns_401_when_not_authenticated(self) -> None:
+        response = self.client.post(
+            self.url,
+            {"password": "Passw0rd!"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_verify_password_returns_401_when_password_is_invalid(self) -> None:
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            self.url,
+            {"password": "wrong-password"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["code"], ErrorMessages.INVALID_PASSWORD.name)
+
+    def test_verify_password_returns_400_for_social_only_user(self) -> None:
+        self.user.set_unusable_password()
+        self.user.save(update_fields=["password"])
+        SocialUser.objects.create(
+            user=self.user,
+            provider=SocialUser.Provider.KAKAO,
+            provider_uid="kakao-123",
+        )
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            self.url,
+            {"password": "Passw0rd!"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["code"], ErrorMessages.SOCIAL_USER_ONLY.name)

--- a/apps/users/tests/test_verify_password.py
+++ b/apps/users/tests/test_verify_password.py
@@ -71,3 +71,17 @@ class UserPasswordVerifyAPITest(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()["code"], ErrorMessages.SOCIAL_USER_ONLY.name)
+
+    def test_verify_password_returns_401_for_deactivated_user(self) -> None:
+        self.user.is_active = False
+        self.user.save(update_fields=["is_active"])
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            self.url,
+            {"password": "Passw0rd!"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["code"], ErrorMessages.ACCOUNT_DEACTIVATED.name)

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -9,7 +9,7 @@ from apps.users.views.auth import (
     RefreshAPIView,
     SignupAPIView,
 )
-from apps.users.views.me import UserMeAPIView
+from apps.users.views.me import UserMeAPIView, UserPasswordVerifyAPIView
 from apps.users.views.social_auth import (
     KakaoCallbackAPIView,
     KakaoLoginAPIView,
@@ -24,6 +24,7 @@ urlpatterns = [
     path("auth/password/reset/", PasswordResetAPIView.as_view(), name="auth-password-reset"),
     path("auth/me/", AuthMeAPIView.as_view(), name="auth-me"),
     path("users/me/", UserMeAPIView.as_view(), name="users-me"),
+    path("users/me/verify-password/", UserPasswordVerifyAPIView.as_view(), name="users-me-verify-password"),
     path("auth/kakao/login/", KakaoLoginAPIView.as_view(), name="auth-kakao-login"),
     path("auth/kakao/callback/", KakaoCallbackAPIView.as_view(), name="auth-kakao-callback"),
 ]

--- a/apps/users/views/me.py
+++ b/apps/users/views/me.py
@@ -5,14 +5,17 @@ from rest_framework import generics, serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from apps.users.models.user import User
+from apps.users.serializers.auth import MessageResponseSerializer
 from apps.users.serializers.me import (
     UserMeResponseSerializer,
     UserMeUpdateRequestSerializer,
     UserMeUpdateResponseSerializer,
+    UserPasswordVerifyRequestSerializer,
 )
-from apps.users.services import get_user_me, update_user_me
+from apps.users.services import get_user_me, update_user_me, verify_user_password
 
 
 @extend_schema(tags=["Users"])
@@ -51,3 +54,23 @@ class UserMeAPIView(generics.RetrieveUpdateAPIView[User]):
         updated_user = update_user_me(instance, **serializer.validated_data)
         response_serializer = UserMeUpdateResponseSerializer(updated_user)
         return Response(response_serializer.data)
+
+
+@extend_schema(
+    summary="비밀번호 확인",
+    request=UserPasswordVerifyRequestSerializer,
+    responses={200: MessageResponseSerializer},
+    tags=["Users"],
+)
+class UserPasswordVerifyAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request) -> Response:
+        serializer = UserPasswordVerifyRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        verify_user_password(
+            cast(User, request.user),
+            password=cast(str, serializer.validated_data["password"]),
+        )
+        return Response(MessageResponseSerializer({"message": "비밀번호가 확인되었습니다."}).data)


### PR DESCRIPTION
## ✅ PR 요약
- 현재 비밀번호를 검증하는 `verify-password` API를 추가했습니다.

## 📄 상세 내용
-  `POST /api/v1/users/me/verify-password/` 엔드포인트를 추가하고 인증된 사용자의 현재 비밀번호 검증 로직을 구현했습니다.
-  소셜 로그인 전용 계정은 로컬 비밀번호 검증이 불가능해 `SOCIAL_USER_ONLY`를 반환하도록 처리했습니다.
-  비밀번호 불일치 상황을 위해 `INVALID_PASSWORD` 에러를 추가하고, 성공/실패/소셜 계정 케이스 테스트를 작성했습니다.

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
