### PR TITLE
[Feature/users/delete-me] 회원 탈퇴 soft delete 및 7일 후 완전 삭제 추가

### DIFF
--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -36,5 +36,10 @@ class UserMeUpdateRequestSerializer(serializers.Serializer[dict[str, object]]):
     birth_date = serializers.DateField(required=False)
 
 
+<<<<<<< HEAD
 class UserPasswordVerifyRequestSerializer(serializers.Serializer[dict[str, object]]):
     password = serializers.CharField(write_only=True)
+=======
+class UserMeDeleteResponseSerializer(serializers.Serializer[dict[str, object]]):
+    message = serializers.CharField()
+>>>>>>> 614a6fb (feat(users): add soft delete and purge for user accounts)

--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -36,10 +36,9 @@ class UserMeUpdateRequestSerializer(serializers.Serializer[dict[str, object]]):
     birth_date = serializers.DateField(required=False)
 
 
-<<<<<<< HEAD
 class UserPasswordVerifyRequestSerializer(serializers.Serializer[dict[str, object]]):
     password = serializers.CharField(write_only=True)
-=======
+
+
 class UserMeDeleteResponseSerializer(serializers.Serializer[dict[str, object]]):
     message = serializers.CharField()
->>>>>>> 614a6fb (feat(users): add soft delete and purge for user accounts)

--- a/apps/users/services/__init__.py
+++ b/apps/users/services/__init__.py
@@ -9,10 +9,12 @@ from .auth_service import (
     signup_user,
 )
 from .social_auth_service import build_kakao_login_url, handle_kakao_callback
+from .user_me_service import delete_user_me, get_user_me, update_user_me
 from .user_me_service import get_user_me, update_user_me, verify_user_password
 
 __all__ = [
     "authenticate_user",
+    "delete_user_me",
     "get_active_user_or_deactivated",
     "get_user_me",
     "issue_auth_tokens",

--- a/apps/users/services/__init__.py
+++ b/apps/users/services/__init__.py
@@ -9,8 +9,7 @@ from .auth_service import (
     signup_user,
 )
 from .social_auth_service import build_kakao_login_url, handle_kakao_callback
-from .user_me_service import delete_user_me, get_user_me, update_user_me
-from .user_me_service import get_user_me, update_user_me, verify_user_password
+from .user_me_service import delete_user_me, get_user_me, update_user_me, verify_user_password
 
 __all__ = [
     "authenticate_user",

--- a/apps/users/services/user_me_service.py
+++ b/apps/users/services/user_me_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import date
 
+from django.utils import timezone
+
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
@@ -33,6 +35,14 @@ def update_user_me(user: User, *, nickname: str | None = None, birth_date: date 
         user.save(update_fields=update_fields + ["updated_at"])
 
     return user
+
+
+def delete_user_me(user: User) -> dict[str, object]:
+    user = get_user_me(user)
+    user.deleted_at = timezone.now()
+    user.is_active = False
+    user.save(update_fields=["deleted_at", "is_active", "updated_at"])
+    return {"message": "계정이 삭제되었습니다."}
 
 
 def verify_user_password(user: User, *, password: str) -> None:

--- a/apps/users/tasks.py
+++ b/apps/users/tasks.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from celery import shared_task
+from django.utils import timezone
+
+from apps.users.models import User
+
+SOFT_DELETE_RETENTION_DAYS = 7
+
+
+@shared_task
+def purge_soft_deleted_users() -> int:
+    cutoff = timezone.now() - timedelta(days=SOFT_DELETE_RETENTION_DAYS)
+    queryset = User.objects.filter(deleted_at__isnull=False, deleted_at__lte=cutoff)
+    deleted_user_count = queryset.count()
+    queryset.delete()
+    return deleted_user_count

--- a/apps/users/tests/test_user_me.py
+++ b/apps/users/tests/test_user_me.py
@@ -7,6 +7,8 @@ from django.utils import timezone
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
+from apps.users.tasks import purge_soft_deleted_users
+
 
 class UserMeRetrieveAPITest(TestCase):
     def setUp(self) -> None:
@@ -121,3 +123,40 @@ class UserMeRetrieveAPITest(TestCase):
             format="json",
         )
         self.assertEqual(res.status_code, 400)
+
+    def test_delete_me_soft_deletes_user(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        res = client.delete("/api/v1/users/me/")
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json(), {"message": "계정이 삭제되었습니다."})
+        self.user.refresh_from_db()
+        self.assertIsNotNone(self.user.deleted_at)
+        self.assertFalse(self.user.is_active)
+
+    def test_delete_me_returns_401_when_not_authenticated(self) -> None:
+        res = self.client.delete("/api/v1/users/me/")
+
+        self.assertEqual(res.status_code, 401)
+
+    def test_purge_soft_deleted_users_deletes_users_after_7_days(self) -> None:
+        self.user.deleted_at = timezone.now() - datetime.timedelta(days=8)
+        self.user.is_active = False
+        self.user.save(update_fields=["deleted_at", "is_active"])
+
+        deleted_count = purge_soft_deleted_users()
+
+        self.assertEqual(deleted_count, 1)
+        self.assertFalse(get_user_model().objects.filter(id=self.user.id).exists())
+
+    def test_purge_soft_deleted_users_keeps_recently_deleted_users(self) -> None:
+        self.user.deleted_at = timezone.now() - datetime.timedelta(days=6)
+        self.user.is_active = False
+        self.user.save(update_fields=["deleted_at", "is_active"])
+
+        deleted_count = purge_soft_deleted_users()
+
+        self.assertEqual(deleted_count, 0)
+        self.assertTrue(get_user_model().objects.filter(id=self.user.id).exists())

--- a/apps/users/views/me.py
+++ b/apps/users/views/me.py
@@ -10,19 +10,24 @@ from rest_framework.views import APIView
 from apps.users.models.user import User
 from apps.users.serializers.auth import MessageResponseSerializer
 from apps.users.serializers.me import (
+    UserMeDeleteResponseSerializer,
     UserMeResponseSerializer,
     UserMeUpdateRequestSerializer,
     UserMeUpdateResponseSerializer,
     UserPasswordVerifyRequestSerializer,
 )
+<<<<<<< HEAD
 from apps.users.services import get_user_me, update_user_me, verify_user_password
+=======
+from apps.users.services import delete_user_me, get_user_me, update_user_me
+>>>>>>> 614a6fb (feat(users): add soft delete and purge for user accounts)
 
 
 @extend_schema(tags=["Users"])
-class UserMeAPIView(generics.RetrieveUpdateAPIView[User]):
+class UserMeAPIView(generics.RetrieveUpdateDestroyAPIView[User]):
     permission_classes = [IsAuthenticated]
     serializer_class = UserMeResponseSerializer
-    http_method_names = ["get", "patch"]
+    http_method_names = ["get", "patch", "delete"]
 
     def get_object(self) -> User:
         return get_user_me(cast(User, self.request.user))
@@ -55,6 +60,7 @@ class UserMeAPIView(generics.RetrieveUpdateAPIView[User]):
         response_serializer = UserMeUpdateResponseSerializer(updated_user)
         return Response(response_serializer.data)
 
+<<<<<<< HEAD
 
 @extend_schema(
     summary="비밀번호 확인",
@@ -74,3 +80,13 @@ class UserPasswordVerifyAPIView(APIView):
             password=cast(str, serializer.validated_data["password"]),
         )
         return Response(MessageResponseSerializer({"message": "비밀번호가 확인되었습니다."}).data)
+=======
+    @extend_schema(
+        summary="회원 탈퇴",
+        responses={200: UserMeDeleteResponseSerializer},
+    )
+    def delete(self, request: Request, *args: object, **kwargs: object) -> Response:
+        result = delete_user_me(self.get_object())
+        response_serializer = UserMeDeleteResponseSerializer(result)
+        return Response(response_serializer.data)
+>>>>>>> 614a6fb (feat(users): add soft delete and purge for user accounts)

--- a/apps/users/views/me.py
+++ b/apps/users/views/me.py
@@ -16,11 +16,7 @@ from apps.users.serializers.me import (
     UserMeUpdateResponseSerializer,
     UserPasswordVerifyRequestSerializer,
 )
-<<<<<<< HEAD
-from apps.users.services import get_user_me, update_user_me, verify_user_password
-=======
-from apps.users.services import delete_user_me, get_user_me, update_user_me
->>>>>>> 614a6fb (feat(users): add soft delete and purge for user accounts)
+from apps.users.services import delete_user_me, get_user_me, update_user_me, verify_user_password
 
 
 @extend_schema(tags=["Users"])
@@ -60,7 +56,16 @@ class UserMeAPIView(generics.RetrieveUpdateDestroyAPIView[User]):
         response_serializer = UserMeUpdateResponseSerializer(updated_user)
         return Response(response_serializer.data)
 
-<<<<<<< HEAD
+    @extend_schema(
+        summary="회원 탈퇴",
+        responses={200: UserMeDeleteResponseSerializer},
+    )
+    def delete(self, request: Request, *args: object, **kwargs: object) -> Response:
+        delete_user_me(self.get_object())
+        result: dict[str, object] = {"message": "계정이 삭제되었습니다."}
+        response_serializer = UserMeDeleteResponseSerializer(result)
+        return Response(response_serializer.data)
+
 
 @extend_schema(
     summary="비밀번호 확인",
@@ -80,13 +85,3 @@ class UserPasswordVerifyAPIView(APIView):
             password=cast(str, serializer.validated_data["password"]),
         )
         return Response(MessageResponseSerializer({"message": "비밀번호가 확인되었습니다."}).data)
-=======
-    @extend_schema(
-        summary="회원 탈퇴",
-        responses={200: UserMeDeleteResponseSerializer},
-    )
-    def delete(self, request: Request, *args: object, **kwargs: object) -> Response:
-        result = delete_user_me(self.get_object())
-        response_serializer = UserMeDeleteResponseSerializer(result)
-        return Response(response_serializer.data)
->>>>>>> 614a6fb (feat(users): add soft delete and purge for user accounts)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -256,6 +256,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "apps.games.tasks.incremental_sync",
         "schedule": crontab(hour=3, minute=0),
     },
+    "users-purge-soft-deleted": {
+        "task": "apps.users.tasks.purge_soft_deleted_users",
+        "schedule": crontab(hour=4, minute=0),
+    },
     "igdb-incremental-sync": {
         "task": "apps.games.igdb.tasks.incremental_sync",
         "schedule": crontab(hour=2, minute=0),  # rawg와 1시간 간격


### PR DESCRIPTION
## ✅ PR 요약
- `DELETE /api/v1/users/me/` 회원 탈퇴 API를 추가하고, 탈퇴 계정에 대한 7일 후 완전 삭제 작업을 구현했습니다.

## 📄 상세 내용
- `DELETE /api/v1/users/me/` 엔드포인트를 추가하고 `deleted_at` 기록과 `is_active=False` 처리로 soft delete를 구현했습니다.
- 회원 탈퇴 성공 시 `{"message": "계정이 삭제되었습니다."}` 응답을 반환하도록 serializer/service/view를 추가했습니다.
- `apps.users.tasks.purge_soft_deleted_users` Celery task를 추가하고, soft delete 후 7일이 지난 계정을 매일 정리하도록 beat 스케줄을 연결했습니다.
- 탈퇴 성공, 미인증 요청, 7일 경과 계정 purge, 7일 미만 계정 유지 테스트를 추가했습니다.

## 🧪 테스트
- 로컬에서 확인했습니다.
