### PR TITLE
[Feature/users/restore-me] 탈퇴 계정 복구 API 추가

### DIFF
--- a/apps/core/exceptions/exception_message.py
+++ b/apps/core/exceptions/exception_message.py
@@ -39,6 +39,8 @@ class ErrorMessages(Enum):
     INVALID_STATE = (400, "유효하지 않은 state 파라미터입니다.")
     OAUTH_CALLBACK_ERROR = (400, "카카오 인증에 실패했습니다.")
     ADULT_VERIFICATION_CALLBACK_ERROR = (400, "비바톤 인증에 실패했습니다.")
+    ACCOUNT_NOT_DELETED = (400, "탈퇴한 계정만 복구할 수 있습니다.")
+    ACCOUNT_RESTORE_EXPIRED = (400, "탈퇴 후 7일이 지나 계정을 복구할 수 없습니다.")
 
     # 401 Unauthorized
     UNAUTHORIZED = (401, "인증이 필요합니다.")

--- a/apps/users/serializers/auth.py
+++ b/apps/users/serializers/auth.py
@@ -38,6 +38,11 @@ class LoginRequestSerializer(serializers.Serializer[dict[str, object]]):
     password = serializers.CharField(write_only=True)
 
 
+class AccountRestoreRequestSerializer(serializers.Serializer[dict[str, object]]):
+    email = serializers.EmailField(required=True)
+    password = serializers.CharField(write_only=True)
+
+
 class PasswordResetRequestSerializer(serializers.Serializer[dict[str, object]]):
     email = serializers.EmailField()
     code = serializers.CharField(min_length=6, max_length=6)

--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -42,7 +42,3 @@ class UserMeDeleteResponseSerializer(serializers.Serializer[dict[str, object]]):
 
 class UserPasswordVerifyRequestSerializer(serializers.Serializer[dict[str, object]]):
     password = serializers.CharField(write_only=True)
-
-
-class UserMeDeleteResponseSerializer(serializers.Serializer[dict[str, object]]):
-    message = serializers.CharField()

--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -36,6 +36,10 @@ class UserMeUpdateRequestSerializer(serializers.Serializer[dict[str, object]]):
     birth_date = serializers.DateField(required=False)
 
 
+class UserMeDeleteResponseSerializer(serializers.Serializer[dict[str, object]]):
+    message = serializers.CharField()
+
+
 class UserPasswordVerifyRequestSerializer(serializers.Serializer[dict[str, object]]):
     password = serializers.CharField(write_only=True)
 

--- a/apps/users/services/__init__.py
+++ b/apps/users/services/__init__.py
@@ -5,6 +5,7 @@ from .auth_service import (
     logout_user,
     refresh_access_token,
     reset_user_password,
+    restore_user_account,
     send_email_code,
     signup_user,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "logout_user",
     "refresh_access_token",
     "reset_user_password",
+    "restore_user_account",
     "send_email_code",
     "signup_user",
     "update_user_me",

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import secrets
-from datetime import date
+from datetime import date, timedelta
 
 from django.conf import settings
 from django.contrib.auth.password_validation import validate_password
 from django.core.cache import cache
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.mail import send_mail
+from django.utils import timezone
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken, OutstandingToken
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -22,6 +23,7 @@ EMAIL_CODE_VERIFY_MAX_ATTEMPTS = 5
 EMAIL_CODE_VERIFY_BLOCK_SECONDS = 20 * 60
 EMAIL_CODE_PURPOSE_SIGNUP = "signup"
 EMAIL_CODE_PURPOSE_PASSWORD_RESET = "password_reset"
+ACCOUNT_RESTORE_RETENTION_DAYS = 7
 
 
 def _email_code_key(*, purpose: str, email: str) -> str:
@@ -110,6 +112,23 @@ def authenticate_user(*, email: str, password: str) -> User:
         raise CustomAPIException(ErrorMessages.INVALID_CREDENTIALS)
 
     return user
+
+
+def restore_user_account(*, email: str, password: str) -> None:
+    user = User.objects.filter(email=email).first()
+    if user is None or not user.check_password(password):
+        raise CustomAPIException(ErrorMessages.INVALID_CREDENTIALS)
+
+    if user.deleted_at is None:
+        raise CustomAPIException(ErrorMessages.ACCOUNT_NOT_DELETED)
+
+    restore_deadline = user.deleted_at + timedelta(days=ACCOUNT_RESTORE_RETENTION_DAYS)
+    if restore_deadline < timezone.now():
+        raise CustomAPIException(ErrorMessages.ACCOUNT_RESTORE_EXPIRED)
+
+    user.deleted_at = None
+    user.is_active = True
+    user.save(update_fields=["deleted_at", "is_active", "updated_at"])
 
 
 def revoke_all_refresh_tokens(user: User) -> None:

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -8,6 +8,7 @@ from django.contrib.auth.password_validation import validate_password
 from django.core.cache import cache
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.mail import send_mail
+from django.db import transaction
 from django.utils import timezone
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken, OutstandingToken
@@ -23,7 +24,6 @@ EMAIL_CODE_VERIFY_MAX_ATTEMPTS = 5
 EMAIL_CODE_VERIFY_BLOCK_SECONDS = 20 * 60
 EMAIL_CODE_PURPOSE_SIGNUP = "signup"
 EMAIL_CODE_PURPOSE_PASSWORD_RESET = "password_reset"
-ACCOUNT_RESTORE_RETENTION_DAYS = 7
 
 
 def _email_code_key(*, purpose: str, email: str) -> str:
@@ -115,20 +115,21 @@ def authenticate_user(*, email: str, password: str) -> User:
 
 
 def restore_user_account(*, email: str, password: str) -> None:
-    user = User.objects.filter(email=email).first()
-    if user is None or not user.check_password(password):
-        raise CustomAPIException(ErrorMessages.INVALID_CREDENTIALS)
+    with transaction.atomic():
+        user = User.objects.select_for_update().filter(email=email).first()
+        if user is None or not user.check_password(password):
+            raise CustomAPIException(ErrorMessages.INVALID_CREDENTIALS)
 
-    if user.deleted_at is None:
-        raise CustomAPIException(ErrorMessages.ACCOUNT_NOT_DELETED)
+        if user.deleted_at is None:
+            raise CustomAPIException(ErrorMessages.ACCOUNT_NOT_DELETED)
 
-    restore_deadline = user.deleted_at + timedelta(days=ACCOUNT_RESTORE_RETENTION_DAYS)
-    if restore_deadline < timezone.now():
-        raise CustomAPIException(ErrorMessages.ACCOUNT_RESTORE_EXPIRED)
+        restore_deadline = user.deleted_at + timedelta(days=settings.ACCOUNT_DELETION_RETENTION_DAYS)
+        if restore_deadline < timezone.now():
+            raise CustomAPIException(ErrorMessages.ACCOUNT_RESTORE_EXPIRED)
 
-    user.deleted_at = None
-    user.is_active = True
-    user.save(update_fields=["deleted_at", "is_active", "updated_at"])
+        user.deleted_at = None
+        user.is_active = True
+        user.save(update_fields=["deleted_at", "is_active", "updated_at"])
 
 
 def revoke_all_refresh_tokens(user: User) -> None:

--- a/apps/users/services/user_me_service.py
+++ b/apps/users/services/user_me_service.py
@@ -37,12 +37,11 @@ def update_user_me(user: User, *, nickname: str | None = None, birth_date: date 
     return user
 
 
-def delete_user_me(user: User) -> dict[str, object]:
+def delete_user_me(user: User) -> None:
     user = get_user_me(user)
     user.deleted_at = timezone.now()
     user.is_active = False
     user.save(update_fields=["deleted_at", "is_active", "updated_at"])
-    return {"message": "계정이 삭제되었습니다."}
 
 
 def verify_user_password(user: User, *, password: str) -> None:

--- a/apps/users/tasks.py
+++ b/apps/users/tasks.py
@@ -3,16 +3,15 @@ from __future__ import annotations
 from datetime import timedelta
 
 from celery import shared_task
+from django.conf import settings
 from django.utils import timezone
 
 from apps.users.models import User
 
-SOFT_DELETE_RETENTION_DAYS = 7
-
 
 @shared_task
 def purge_soft_deleted_users() -> int:
-    cutoff = timezone.now() - timedelta(days=SOFT_DELETE_RETENTION_DAYS)
+    cutoff = timezone.now() - timedelta(days=settings.ACCOUNT_DELETION_RETENTION_DAYS)
     queryset = User.objects.filter(deleted_at__isnull=False, deleted_at__lte=cutoff)
     deleted_user_count = queryset.count()
     queryset.delete()

--- a/apps/users/tests/test_login.py
+++ b/apps/users/tests/test_login.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.test import TestCase
+from django.utils import timezone
 from rest_framework.test import APIClient
 
 from apps.core.exceptions.exception_message import ErrorMessages
@@ -61,3 +62,17 @@ class LoginAPITestCase(TestCase):
         self.assertEqual(res.status_code, 401)
         data = res.json()
         self.assertEqual(data["code"], ErrorMessages.INVALID_CREDENTIALS.name)
+
+    def test_login_deleted_user_returns_401(self) -> None:
+        self.user.deleted_at = timezone.now()
+        self.user.is_active = False
+        self.user.save(update_fields=["deleted_at", "is_active"])
+
+        res = self.client.post(
+            "/api/v1/auth/login/",
+            {"email": "admin@example.com", "password": "password1100110011"},
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(res.json()["code"], ErrorMessages.ACCOUNT_DEACTIVATED.name)

--- a/apps/users/tests/test_restore_account.py
+++ b/apps/users/tests/test_restore_account.py
@@ -1,0 +1,75 @@
+import datetime
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.users.models.user import User
+
+
+class AccountRestoreAPITestCase(TestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/auth/restore/"
+        self.user = User.objects.create_user(
+            email="restore@example.com",
+            nickname="restore-user",
+            birth_date=datetime.date(1999, 1, 1),
+            password="Passw0rd!",
+        )
+
+    def test_restore_account_success(self) -> None:
+        self.user.deleted_at = timezone.now() - datetime.timedelta(days=3)
+        self.user.is_active = False
+        self.user.save(update_fields=["deleted_at", "is_active"])
+
+        response = self.client.post(
+            self.url,
+            {"email": "restore@example.com", "password": "Passw0rd!"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"message": "계정이 복구되었습니다."})
+        self.user.refresh_from_db()
+        self.assertIsNone(self.user.deleted_at)
+        self.assertTrue(self.user.is_active)
+
+    def test_restore_account_returns_400_when_account_not_deleted(self) -> None:
+        response = self.client.post(
+            self.url,
+            {"email": "restore@example.com", "password": "Passw0rd!"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["code"], ErrorMessages.ACCOUNT_NOT_DELETED.name)
+
+    def test_restore_account_returns_400_when_restore_window_expired(self) -> None:
+        self.user.deleted_at = timezone.now() - datetime.timedelta(days=8)
+        self.user.is_active = False
+        self.user.save(update_fields=["deleted_at", "is_active"])
+
+        response = self.client.post(
+            self.url,
+            {"email": "restore@example.com", "password": "Passw0rd!"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["code"], ErrorMessages.ACCOUNT_RESTORE_EXPIRED.name)
+
+    def test_restore_account_returns_401_for_invalid_password(self) -> None:
+        self.user.deleted_at = timezone.now() - datetime.timedelta(days=3)
+        self.user.is_active = False
+        self.user.save(update_fields=["deleted_at", "is_active"])
+
+        response = self.client.post(
+            self.url,
+            {"email": "restore@example.com", "password": "wrong-password"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["code"], ErrorMessages.INVALID_CREDENTIALS.name)

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -6,6 +6,7 @@ from apps.users.views.adult_verification import (
     AdultVerificationStatusAPIView,
 )
 from apps.users.views.auth import (
+    AccountRestoreAPIView,
     AuthMeAPIView,
     EmailCodeSendAPIView,
     LoginAPIView,
@@ -25,6 +26,7 @@ urlpatterns = [
     path("auth/email/code/", EmailCodeSendAPIView.as_view(), name="auth-email-code"),
     path("auth/login/", LoginAPIView.as_view(), name="auth-login"),
     path("auth/logout/", LogoutAPIView.as_view(), name="auth-logout"),
+    path("auth/restore/", AccountRestoreAPIView.as_view(), name="auth-restore"),
     path("auth/refresh/", RefreshAPIView.as_view(), name="auth-refresh"),
     path("auth/password/reset/", PasswordResetAPIView.as_view(), name="auth-password-reset"),
     path("auth/me/", AuthMeAPIView.as_view(), name="auth-me"),

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -9,6 +9,7 @@ from rest_framework.views import APIView
 
 from apps.users.models.user import User
 from apps.users.serializers.auth import (
+    AccountRestoreRequestSerializer,
     AuthMeResponseSerializer,
     EmailCodeSendRequestSerializer,
     EmailCodeSendResponseSerializer,
@@ -26,6 +27,7 @@ from apps.users.services import (
     logout_user,
     refresh_access_token,
     reset_user_password,
+    restore_user_account,
     send_email_code,
     signup_user,
 )
@@ -158,6 +160,24 @@ class PasswordResetAPIView(APIView):
 
         reset_user_password(**serializer.validated_data)
         response_serializer = MessageResponseSerializer({"message": "비밀번호가 재설정되었습니다."})
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+
+@extend_schema(
+    summary="탈퇴 계정 복구",
+    request=AccountRestoreRequestSerializer,
+    responses={200: MessageResponseSerializer},
+    tags=["auth"],
+)
+class AccountRestoreAPIView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request: Request) -> Response:
+        serializer = AccountRestoreRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        restore_user_account(**serializer.validated_data)
+        response_serializer = MessageResponseSerializer({"message": "계정이 복구되었습니다."})
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -257,6 +257,8 @@ IGDB_CLIENT_SECRET = os.getenv("IGDB_CLIENT_SECRET")
 # Celery Beat 스케줄
 from celery.schedules import crontab  # noqa: E402
 
+ACCOUNT_DELETION_RETENTION_DAYS = int(os.getenv("ACCOUNT_DELETION_RETENTION_DAYS", "7"))
+
 CELERY_BEAT_SCHEDULE = {
     "rawg-incremental-sync": {
         "task": "apps.games.tasks.incremental_sync",


### PR DESCRIPTION
## ✅ PR 요약
- 탈퇴한 계정을 7일 이내에 복구할 수 있는 `POST /api/v1/auth/restore/` API를 추가했습니다.

## 📄 상세 내용
- `POST /api/v1/auth/restore/` 엔드포인트를 추가하고 이메일/비밀번호 기반 계정 복구 로직을 구현했습니다.
- soft delete된 계정만 복구 가능하도록 처리했고, 복구 시 `deleted_at`을 `null`로 되돌리고 `is_active`를 `true`로 복원합니다.
- 탈퇴하지 않은 계정 복구 요청, 복구 가능 기간(7일) 만료, 잘못된 비밀번호 입력에 대한 예외 처리를 추가했습니다.
- 탈퇴 계정 로그인 차단 테스트와 복구 성공/실패 테스트를 작성했습니다.