### PR TITLE
[Feature/users/change-password] 내 정보 수정 비밀번호 변경 API 추가

### DIFF
--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -36,9 +36,13 @@ class UserMeUpdateRequestSerializer(serializers.Serializer[dict[str, object]]):
     birth_date = serializers.DateField(required=False)
 
 
-class UserMeDeleteResponseSerializer(serializers.Serializer[dict[str, object]]):
-    message = serializers.CharField()
-
-
 class UserPasswordVerifyRequestSerializer(serializers.Serializer[dict[str, object]]):
     password = serializers.CharField(write_only=True)
+
+
+class UserPasswordChangeRequestSerializer(serializers.Serializer[dict[str, object]]):
+    new_password = serializers.CharField(write_only=True)
+
+
+class UserMeDeleteResponseSerializer(serializers.Serializer[dict[str, object]]):
+    message = serializers.CharField()

--- a/apps/users/services/__init__.py
+++ b/apps/users/services/__init__.py
@@ -10,10 +10,11 @@ from .auth_service import (
     signup_user,
 )
 from .social_auth_service import build_kakao_login_url, handle_kakao_callback
-from .user_me_service import delete_user_me, get_user_me, update_user_me, verify_user_password
+from .user_me_service import change_user_password, delete_user_me, get_user_me, update_user_me, verify_user_password
 
 __all__ = [
     "authenticate_user",
+    "change_user_password",
     "delete_user_me",
     "get_active_user_or_deactivated",
     "get_user_me",

--- a/apps/users/services/user_me_service.py
+++ b/apps/users/services/user_me_service.py
@@ -70,5 +70,5 @@ def change_user_password(user: User, *, new_password: str) -> None:
         raise CustomAPIException(ErrorMessages.VALIDATION_ERROR) from err
 
     user.set_password(new_password)
-    user.save(update_fields=["password"])
+    user.save(update_fields=["password", "updated_at"])
     revoke_all_refresh_tokens(user)

--- a/apps/users/services/user_me_service.py
+++ b/apps/users/services/user_me_service.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from datetime import date
 
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
 
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
-from apps.users.services.auth_service import get_active_user_or_deactivated
+from apps.users.services.auth_service import get_active_user_or_deactivated, revoke_all_refresh_tokens
 
 
 def get_user_me(user: User) -> User:
@@ -53,3 +55,20 @@ def verify_user_password(user: User, *, password: str) -> None:
 
     if not user.check_password(password):
         raise CustomAPIException(ErrorMessages.INVALID_PASSWORD)
+
+
+def change_user_password(user: User, *, new_password: str) -> None:
+    user = get_user_me(user)
+    get_active_user_or_deactivated(user)
+
+    if user.social_accounts.exists() and not user.has_usable_password():
+        raise CustomAPIException(ErrorMessages.SOCIAL_USER_ONLY)
+
+    try:
+        validate_password(new_password)
+    except DjangoValidationError as err:
+        raise CustomAPIException(ErrorMessages.VALIDATION_ERROR) from err
+
+    user.set_password(new_password)
+    user.save(update_fields=["password"])
+    revoke_all_refresh_tokens(user)

--- a/apps/users/tests/test_change_password.py
+++ b/apps/users/tests/test_change_password.py
@@ -1,0 +1,83 @@
+import datetime
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.users.models.social_user import SocialUser
+
+
+class UserPasswordChangeAPITest(TestCase):
+    def setUp(self) -> None:
+        self.client: APIClient = APIClient()
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            email="change@example.com",
+            password="Passw0rd!",
+            nickname="changeuser",
+            birth_date=datetime.date(1999, 1, 1),
+        )
+        self.url = "/api/v1/users/me/password/"
+
+    def test_change_password_returns_200_when_password_changes(self) -> None:
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.patch(
+            self.url,
+            {
+                "new_password": "NewPassw0rd!",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["message"], "비밀번호가 변경되었습니다.")
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("NewPassw0rd!"))
+
+    def test_change_password_returns_401_when_not_authenticated(self) -> None:
+        response = self.client.patch(
+            self.url,
+            {
+                "new_password": "NewPassw0rd!",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_change_password_returns_400_for_social_only_user(self) -> None:
+        self.user.set_unusable_password()
+        self.user.save(update_fields=["password"])
+        SocialUser.objects.create(
+            user=self.user,
+            provider=SocialUser.Provider.KAKAO,
+            provider_uid="kakao-123",
+        )
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.patch(
+            self.url,
+            {
+                "new_password": "NewPassw0rd!",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["code"], ErrorMessages.SOCIAL_USER_ONLY.name)
+
+    def test_change_password_returns_400_for_invalid_new_password(self) -> None:
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.patch(
+            self.url,
+            {
+                "new_password": "123",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["code"], ErrorMessages.VALIDATION_ERROR.name)

--- a/apps/users/tests/test_change_password.py
+++ b/apps/users/tests/test_change_password.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.urls import reverse
 from rest_framework.test import APIClient
 
 from apps.core.exceptions.exception_message import ErrorMessages
@@ -18,7 +19,7 @@ class UserPasswordChangeAPITest(TestCase):
             nickname="changeuser",
             birth_date=datetime.date(1999, 1, 1),
         )
-        self.url = "/api/v1/users/me/password/"
+        self.url = reverse("users-me-password-change")
 
     def test_change_password_returns_200_when_password_changes(self) -> None:
         self.client.force_authenticate(user=self.user)

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -15,7 +15,7 @@ from apps.users.views.auth import (
     RefreshAPIView,
     SignupAPIView,
 )
-from apps.users.views.me import UserMeAPIView, UserPasswordVerifyAPIView
+from apps.users.views.me import UserMeAPIView, UserPasswordChangeAPIView, UserPasswordVerifyAPIView
 from apps.users.views.social_auth import (
     KakaoCallbackAPIView,
     KakaoLoginAPIView,
@@ -32,6 +32,7 @@ urlpatterns = [
     path("auth/me/", AuthMeAPIView.as_view(), name="auth-me"),
     path("users/me/", UserMeAPIView.as_view(), name="users-me"),
     path("users/me/verify-password/", UserPasswordVerifyAPIView.as_view(), name="users-me-verify-password"),
+    path("users/me/password/", UserPasswordChangeAPIView.as_view(), name="users-me-password-change"),
     path("auth/kakao/login/", KakaoLoginAPIView.as_view(), name="auth-kakao-login"),
     path("auth/kakao/callback/", KakaoCallbackAPIView.as_view(), name="auth-kakao-callback"),
     path(

--- a/apps/users/views/me.py
+++ b/apps/users/views/me.py
@@ -14,9 +14,16 @@ from apps.users.serializers.me import (
     UserMeResponseSerializer,
     UserMeUpdateRequestSerializer,
     UserMeUpdateResponseSerializer,
+    UserPasswordChangeRequestSerializer,
     UserPasswordVerifyRequestSerializer,
 )
-from apps.users.services import delete_user_me, get_user_me, update_user_me, verify_user_password
+from apps.users.services import (
+    change_user_password,
+    delete_user_me,
+    get_user_me,
+    update_user_me,
+    verify_user_password,
+)
 
 
 @extend_schema(tags=["Users"])
@@ -85,3 +92,23 @@ class UserPasswordVerifyAPIView(APIView):
             password=cast(str, serializer.validated_data["password"]),
         )
         return Response(MessageResponseSerializer({"message": "비밀번호가 확인되었습니다."}).data)
+
+
+@extend_schema(
+    summary="비밀번호 변경",
+    request=UserPasswordChangeRequestSerializer,
+    responses={200: MessageResponseSerializer},
+    tags=["Users"],
+)
+class UserPasswordChangeAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def patch(self, request: Request) -> Response:
+        serializer = UserPasswordChangeRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        change_user_password(
+            cast(User, request.user),
+            new_password=cast(str, serializer.validated_data["new_password"]),
+        )
+        return Response(MessageResponseSerializer({"message": "비밀번호가 변경되었습니다."}).data)


### PR DESCRIPTION
## ✅ PR 요약
- 내 정보 수정 페이지에서 사용할 비밀번호 변경 API를 추가했습니다.

## 📄 상세 내용
- `PATCH /api/v1/users/me/password/` 엔드포인트를 추가했습니다.
- 수정 페이지 진입 전 비밀번호 검증은 기존 `POST /api/v1/users/me/verify-password/`에서 처리하고, 본 API는 새 비밀번호 저장만 담당하도록 구현했습니다.
- 새 비밀번호는 Django 기본 비밀번호 검증을 통과해야 하며, 소셜 로그인 전용 계정은 변경할 수 없도록 처리했습니다.
- 비밀번호 변경 시 기존 refresh token들을 무효화하도록 처리했습니다.
- 성공, 미인증, 소셜 전용 계정, 새 비밀번호 유효성 실패 테스트를 추가했습니다.