### PR TITLE
[Feature/admin/interaction-context-rules] 맥락 가중치 목록 조회 API 추가

### DIFF
--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -85,6 +85,16 @@ class InteractionStoreClickLogResponseSerializer(serializers.Serializer):  # typ
     logged_at = serializers.DateTimeField(source="created_at")
 
 
+class InteractionContextRuleItemSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    interaction_source = serializers.CharField()
+    multiplier = serializers.DecimalField(max_digits=4, decimal_places=2)
+    updated_at = serializers.DateTimeField()
+
+
+class InteractionContextRuleListResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    results = InteractionContextRuleItemSerializer(many=True)
+
+
 class InteractionWeightRuleItemSerializer(serializers.Serializer):  # type: ignore[type-arg]
     interaction_type = serializers.CharField()
     base_weight = serializers.DecimalField(max_digits=4, decimal_places=2)

--- a/apps/interactions/services/__init__.py
+++ b/apps/interactions/services/__init__.py
@@ -1,3 +1,4 @@
+from .admin_context_rule_service import InteractionAdminContextRuleService
 from .admin_weight_rule_service import InteractionAdminRuleService
 from .view_log_service import (
     record_search_interaction,
@@ -6,6 +7,7 @@ from .view_log_service import (
 )
 
 __all__ = [
+    "InteractionAdminContextRuleService",
     "InteractionAdminRuleService",
     "record_view_interaction",
     "record_search_interaction",

--- a/apps/interactions/services/admin_context_rule_service.py
+++ b/apps/interactions/services/admin_context_rule_service.py
@@ -16,10 +16,7 @@ class InteractionAdminContextRuleService:
     @classmethod
     def list_context_rules(cls) -> QuerySet[InteractionContextRule]:
         order_case = Case(
-            *[
-                When(interaction_source=source, then=index)
-                for index, source in enumerate(cls.ORDERED_SOURCES)
-            ],
+            *[When(interaction_source=source, then=index) for index, source in enumerate(cls.ORDERED_SOURCES)],
             default=len(cls.ORDERED_SOURCES),
             output_field=IntegerField(),
         )

--- a/apps/interactions/services/admin_context_rule_service.py
+++ b/apps/interactions/services/admin_context_rule_service.py
@@ -1,0 +1,26 @@
+from django.db.models import Case, IntegerField, QuerySet, When
+
+from apps.interactions.models import InteractionContextRule
+
+
+class InteractionAdminContextRuleService:
+    ORDERED_SOURCES = [
+        InteractionContextRule.InteractionSource.LIST_PAGE,
+        InteractionContextRule.InteractionSource.DETAIL_PAGE,
+        InteractionContextRule.InteractionSource.SEARCH_RESULT,
+        InteractionContextRule.InteractionSource.RECOMMENDATION,
+        InteractionContextRule.InteractionSource.SAVED_PAGE,
+        InteractionContextRule.InteractionSource.ONBOARDING,
+    ]
+
+    @classmethod
+    def list_context_rules(cls) -> QuerySet[InteractionContextRule]:
+        order_case = Case(
+            *[
+                When(interaction_source=source, then=index)
+                for index, source in enumerate(cls.ORDERED_SOURCES)
+            ],
+            default=len(cls.ORDERED_SOURCES),
+            output_field=IntegerField(),
+        )
+        return InteractionContextRule.objects.all().order_by(order_case)

--- a/apps/interactions/tests.py
+++ b/apps/interactions/tests.py
@@ -881,6 +881,69 @@ class AdminInteractionWeightRuleListAPITestCase(TestCase):
         self.assertIn("updated_at", first)
 
 
+class AdminInteractionContextRuleListAPITestCase(TestCase):
+    client: APIClient
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/admin/interaction-context-rules/"
+
+    def _create_user(self, *, is_staff: bool = False) -> User:
+        return User.objects.create_user(
+            email=f"admin-context-rule-{is_staff}@ex.com",
+            nickname=f"admin-context-rule-{is_staff}",
+            birth_date=date(1991, 1, 1),
+            password="pw",
+            is_staff=is_staff,
+        )
+
+    def test_admin_interaction_context_rule_list_unauthorized(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_admin_interaction_context_rule_list_forbidden_for_non_staff(self) -> None:
+        user = self._create_user(is_staff=False)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+        data = cast(dict[str, Any], response.data)
+        self.assertEqual(data.get("code"), "FORBIDDEN")
+
+    def test_admin_interaction_context_rule_list_success(self) -> None:
+        admin = self._create_user(is_staff=True)
+        self.client.force_authenticate(user=admin)
+
+        InteractionContextRule.objects.create(
+            interaction_source=InteractionContextRule.InteractionSource.RECOMMENDATION,
+            multiplier=1.40,
+        )
+        InteractionContextRule.objects.create(
+            interaction_source=InteractionContextRule.InteractionSource.LIST_PAGE,
+            multiplier=0.90,
+        )
+        InteractionContextRule.objects.create(
+            interaction_source=InteractionContextRule.InteractionSource.DETAIL_PAGE,
+            multiplier=1.20,
+        )
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        data = cast(dict[str, Any], response.data)
+        self.assertIn("results", data)
+        results = cast(list[dict[str, Any]], data["results"])
+        self.assertEqual(
+            [item["interaction_source"] for item in results],
+            ["list_page", "detail_page", "recommendation"],
+        )
+
+        first = results[0]
+        self.assertEqual(first["interaction_source"], "list_page")
+        self.assertEqual(first["multiplier"], "0.90")
+        self.assertIn("updated_at", first)
+
+
 class AdminInteractionWeightRuleUpdateAPITestCase(TestCase):
     client: APIClient
 

--- a/apps/interactions/urls_admin_context.py
+++ b/apps/interactions/urls_admin_context.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.interactions.views_admin import AdminInteractionContextRuleListView
+
+urlpatterns = [
+    path("", AdminInteractionContextRuleListView.as_view(), name="admin-interaction-context-rule-list"),
+]

--- a/apps/interactions/views_admin.py
+++ b/apps/interactions/views_admin.py
@@ -27,12 +27,17 @@ from apps.users.models import User
 @extend_schema(
     tags=["admin"],
     summary="맥락 가중치 목록 조회",
-    description="관리자 권한으로 맥락(발생 위치)별 가중치 규칙 목록을 조회합니다.",
+    description=(
+        "관리자 권한으로 맥락(발생 위치)별 가중치 규칙 목록을 조회합니다. "
+        "list_page, detail_page, search_result, recommendation, saved_page, onboarding 등 "
+        "interaction_source별 multiplier와 updated_at이 반환됩니다. "
+        "쿼리 파라미터 없이 GET 요청만 보내면 됩니다."
+    ),
     responses={
         200: InteractionContextRuleListResponseSerializer,
         401: OpenApiResponse(
             response=ErrorResponseSerializer,
-            description="Unauthorized",
+            description="인증되지 않음. Authorization 헤더에 유효한 Bearer 토큰이 필요합니다.",
             examples=[
                 OpenApiExample(
                     "인증 필요",
@@ -46,7 +51,7 @@ from apps.users.models import User
         ),
         403: OpenApiResponse(
             response=ErrorResponseSerializer,
-            description="Forbidden",
+            description="권한 없음. is_staff=True인 관리자 계정만 호출할 수 있습니다.",
             examples=[
                 OpenApiExample(
                     "관리자 권한 필요",
@@ -61,14 +66,19 @@ from apps.users.models import User
     },
     examples=[
         OpenApiExample(
-            "응답 예시",
+            "성공 시 응답 예시",
             value={
                 "results": [
+                    {
+                        "interaction_source": "list_page",
+                        "multiplier": "0.90",
+                        "updated_at": "2025-05-01T00:00:00Z",
+                    },
                     {
                         "interaction_source": "recommendation",
                         "multiplier": "1.40",
                         "updated_at": "2025-05-01T00:00:00Z",
-                    }
+                    },
                 ]
             },
             response_only=True,

--- a/apps/interactions/views_admin.py
+++ b/apps/interactions/views_admin.py
@@ -14,12 +14,79 @@ from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
 from apps.core.serializers.error_serializer import ErrorResponseSerializer
 from apps.interactions.serializers import (
+    InteractionContextRuleItemSerializer,
+    InteractionContextRuleListResponseSerializer,
     InteractionWeightRuleItemSerializer,
     InteractionWeightRuleListResponseSerializer,
     InteractionWeightRuleUpdateRequestSerializer,
 )
-from apps.interactions.services import InteractionAdminRuleService
+from apps.interactions.services import InteractionAdminContextRuleService, InteractionAdminRuleService
 from apps.users.models import User
+
+
+@extend_schema(
+    tags=["admin"],
+    summary="맥락 가중치 목록 조회",
+    description="관리자 권한으로 맥락(발생 위치)별 가중치 규칙 목록을 조회합니다.",
+    responses={
+        200: InteractionContextRuleListResponseSerializer,
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Unauthorized",
+            examples=[
+                OpenApiExample(
+                    "인증 필요",
+                    value={
+                        "status_code": ErrorMessages.UNAUTHORIZED.status_code,
+                        "code": ErrorMessages.UNAUTHORIZED.name,
+                        "message": ErrorMessages.UNAUTHORIZED.message,
+                    },
+                )
+            ],
+        ),
+        403: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Forbidden",
+            examples=[
+                OpenApiExample(
+                    "관리자 권한 필요",
+                    value={
+                        "status_code": ErrorMessages.FORBIDDEN.status_code,
+                        "code": ErrorMessages.FORBIDDEN.name,
+                        "message": ErrorMessages.FORBIDDEN.message,
+                    },
+                )
+            ],
+        ),
+    },
+    examples=[
+        OpenApiExample(
+            "응답 예시",
+            value={
+                "results": [
+                    {
+                        "interaction_source": "recommendation",
+                        "multiplier": "1.40",
+                        "updated_at": "2025-05-01T00:00:00Z",
+                    }
+                ]
+            },
+            response_only=True,
+            status_codes=["200"],
+        )
+    ],
+)
+class AdminInteractionContextRuleListView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        user = cast(User, request.user)
+        if not user.is_staff:
+            raise CustomAPIException(ErrorMessages.FORBIDDEN)
+
+        rules = InteractionAdminContextRuleService.list_context_rules()
+        serializer = InteractionContextRuleItemSerializer(rules, many=True)
+        return Response({"results": serializer.data}, status=status.HTTP_200_OK)
 
 
 @extend_schema(

--- a/config/urls.py
+++ b/config/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path("api/v1/preferences/", include("apps.preferences.urls")),
     path("api/v1/interactions/", include("apps.interactions.urls")),
     path("api/v1/admin/interaction-weight-rules/", include("apps.interactions.urls_admin")),
+    path("api/v1/admin/interaction-context-rules/", include("apps.interactions.urls_admin_context")),
     path("api/v1/recommendations/", include("apps.recommendations.urls")),
     path("api/v1/admin/recommendation-jobs/", include("apps.recommendations.urls_admin")),
     path("admin/", admin.site.urls),


### PR DESCRIPTION
## ✅ PR 요약
- GET/api/v1/admin/interaction-context-rules/ 관리자용 맥락 가중치 목록 조회 API

## 📄 상세 내용
- [x] InteractionAdminContextRuleService 추가, list_context_rules() 로 조회·정렬 담당
- [x] AdminInteractionContextRuleListAPITestCase 테스트 추가 (401/403/200)

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] 빌드/린트가 통과합니다. (가능한 경우)

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
