### PR TITLE
[Feature/users/me-password-update-clean] 내 정보 수정 API에 비밀번호 변경 지원 추가

### DIFF
--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -34,6 +34,7 @@ class UserMeUpdateResponseSerializer(serializers.ModelSerializer[User]):
 class UserMeUpdateRequestSerializer(serializers.Serializer[dict[str, object]]):
     nickname = serializers.CharField(required=False, max_length=30)
     birth_date = serializers.DateField(required=False)
+    new_password = serializers.CharField(required=False, write_only=True)
 
 
 class UserPasswordVerifyRequestSerializer(serializers.Serializer[dict[str, object]]):

--- a/apps/users/services/user_me_service.py
+++ b/apps/users/services/user_me_service.py
@@ -18,7 +18,13 @@ def get_user_me(user: User) -> User:
     return user
 
 
-def update_user_me(user: User, *, nickname: str | None = None, birth_date: date | None = None) -> User:
+def update_user_me(
+    user: User,
+    *,
+    nickname: str | None = None,
+    birth_date: date | None = None,
+    new_password: str | None = None,
+) -> User:
     user = get_user_me(user)
     update_fields: list[str] = []
 
@@ -33,8 +39,24 @@ def update_user_me(user: User, *, nickname: str | None = None, birth_date: date 
         user.birth_date = birth_date
         update_fields.append("birth_date")
 
+    if new_password is not None:
+        get_active_user_or_deactivated(user)
+
+        if user.social_accounts.exists() and not user.has_usable_password():
+            raise CustomAPIException(ErrorMessages.SOCIAL_USER_ONLY)
+
+        try:
+            validate_password(new_password)
+        except DjangoValidationError as err:
+            raise CustomAPIException(ErrorMessages.VALIDATION_ERROR) from err
+
+        user.set_password(new_password)
+        update_fields.append("password")
+
     if update_fields:
         user.save(update_fields=update_fields + ["updated_at"])
+        if new_password is not None:
+            revoke_all_refresh_tokens(user)
 
     return user
 

--- a/apps/users/tests/test_user_me.py
+++ b/apps/users/tests/test_user_me.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
+from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.tasks import purge_soft_deleted_users
 
 
@@ -82,6 +83,62 @@ class UserMeRetrieveAPITest(TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.data["nickname"], "onlynickname")
         self.assertEqual(res.data["birth_date"], "1999-01-01")
+
+    def test_patch_me_changes_password_when_new_password_is_provided(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        res = client.patch(
+            "/api/v1/users/me/",
+            {
+                "new_password": "NewPassw0rd!",
+            },
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("NewPassw0rd!"))
+
+    def test_patch_me_returns_400_for_invalid_new_password(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        res = client.patch(
+            "/api/v1/users/me/",
+            {
+                "new_password": "123",
+            },
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json()["code"], ErrorMessages.VALIDATION_ERROR.name)
+
+    def test_patch_me_returns_400_for_social_only_user_with_new_password(self) -> None:
+        from apps.users.models.social_user import SocialUser
+
+        self.user.set_unusable_password()
+        self.user.save(update_fields=["password"])
+        SocialUser.objects.create(
+            user=self.user,
+            provider=SocialUser.Provider.KAKAO,
+            provider_uid="kakao-social-only",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        res = client.patch(
+            "/api/v1/users/me/",
+            {
+                "new_password": "NewPassw0rd!",
+            },
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json()["code"], ErrorMessages.SOCIAL_USER_ONLY.name)
 
     def test_patch_me_returns_401_when_not_authenticated(self) -> None:
         res = self.client.patch(


### PR DESCRIPTION
## ✅ PR 요약
- `PATCH /api/v1/users/me/`에서 프로필 수정과 함께 비밀번호 변경도 처리할 수 있도록 확장했습니다.

## 📄 상세 내용
- [x] `UserMeUpdateRequestSerializer`에 `new_password` 필드를 추가했습니다.
- [x] `update_user_me()`가 닉네임, 생년월일 수정과 함께 비밀번호 변경도 처리하도록 확장했습니다.
- [x] 비밀번호 변경 시 Django 비밀번호 정책 검증을 적용했습니다.
- [x] 소셜 로그인 전용 계정은 기존과 동일하게 `SOCIAL_USER_ONLY` 에러를 반환하도록 처리했습니다.
- [x] 비밀번호 변경 성공 시 기존 refresh token들을 무효화하도록 반영했습니다.
- [x] `PATCH /api/v1/users/me/` 기준 비밀번호 변경 성공/실패 테스트를 추가했습니다.
