### PR TITLE
[Feature/admin/users-management] 관리자 유저 목록/상세 조회 및 상태 변경 API 추가

### DIFF
--- a/apps/core/permissions.py
+++ b/apps/core/permissions.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
+from rest_framework.views import APIView
+
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+
+
+class IsStaffAdmin(BasePermission):
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+        if not user.is_staff:
+            raise CustomAPIException(ErrorMessages.FORBIDDEN)
+        return True

--- a/apps/users/serializers/admin_user.py
+++ b/apps/users/serializers/admin_user.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from apps.users.models.user import User
+
+
+class AdminUserListItemSerializer(serializers.ModelSerializer[User]):
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "email",
+            "nickname",
+            "is_active",
+            "is_staff",
+            "is_superuser",
+            "is_adult_verified",
+            "deleted_at",
+            "created_at",
+        ]
+
+
+class AdminUserListResponseSerializer(serializers.Serializer[dict[str, object]]):
+    count = serializers.IntegerField()
+    next = serializers.CharField(allow_null=True)
+    previous = serializers.CharField(allow_null=True)
+    results = AdminUserListItemSerializer(many=True)
+
+
+class AdminUserDetailResponseSerializer(serializers.ModelSerializer[User]):
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "email",
+            "nickname",
+            "birth_date",
+            "profile_img_url",
+            "is_active",
+            "is_staff",
+            "is_superuser",
+            "is_adult_verified",
+            "adult_verified_at",
+            "adult_verification_expires_at",
+            "deleted_at",
+            "created_at",
+            "updated_at",
+        ]
+
+
+class AdminUserStatusUpdateRequestSerializer(serializers.Serializer[dict[str, object]]):
+    is_active = serializers.BooleanField()

--- a/apps/users/services/__init__.py
+++ b/apps/users/services/__init__.py
@@ -1,3 +1,4 @@
+from .admin_user_service import get_admin_user, list_admin_users, update_admin_user_status
 from .auth_service import (
     authenticate_user,
     get_active_user_or_deactivated,
@@ -29,10 +30,12 @@ __all__ = [
     "clear_recent_searches",
     "delete_recent_search_keyword",
     "delete_user_me",
+    "get_admin_user",
     "get_active_user_or_deactivated",
     "get_recent_searches",
     "get_user_me",
     "issue_auth_tokens",
+    "list_admin_users",
     "logout_user",
     "refresh_access_token",
     "reset_user_password",
@@ -40,6 +43,7 @@ __all__ = [
     "save_recent_search_keyword",
     "send_email_code",
     "signup_user",
+    "update_admin_user_status",
     "update_user_me",
     "verify_user_password",
     "build_discord_login_url",

--- a/apps/users/services/admin_user_service.py
+++ b/apps/users/services/admin_user_service.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from django.db.models import QuerySet
+
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.users.models.user import User
+
+
+def list_admin_users() -> QuerySet[User]:
+    return User.objects.order_by("-created_at")
+
+
+def get_admin_user(*, user_id: int) -> User:
+    user = User.objects.filter(id=user_id).first()
+    if user is None:
+        raise CustomAPIException(ErrorMessages.USER_NOT_FOUND)
+    return user
+
+
+def update_admin_user_status(*, user_id: int, is_active: bool) -> User:
+    user = get_admin_user(user_id=user_id)
+    user.is_active = is_active
+    user.save(update_fields=["is_active", "updated_at"])
+    return user

--- a/apps/users/services/admin_user_service.py
+++ b/apps/users/services/admin_user_service.py
@@ -12,10 +12,10 @@ def list_admin_users() -> QuerySet[User]:
 
 
 def get_admin_user(*, user_id: int) -> User:
-    user = User.objects.filter(id=user_id).first()
-    if user is None:
-        raise CustomAPIException(ErrorMessages.USER_NOT_FOUND)
-    return user
+    try:
+        return User.objects.get(id=user_id)
+    except User.DoesNotExist:
+        raise CustomAPIException(ErrorMessages.USER_NOT_FOUND) from None
 
 
 def update_admin_user_status(*, user_id: int, is_active: bool) -> User:

--- a/apps/users/tests/test_admin_users.py
+++ b/apps/users/tests/test_admin_users.py
@@ -1,0 +1,100 @@
+import datetime
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.core.exceptions.exception_message import ErrorMessages
+
+User = get_user_model()
+
+
+class AdminUserAPITestCase(TestCase):
+    def setUp(self) -> None:
+        self.client: APIClient = APIClient()
+        self.admin_user = User.objects.create_superuser(
+            email="admin@example.com",
+            nickname="admin-user",
+            birth_date=datetime.date(1990, 1, 1),
+            password="Admin1234!",
+        )
+        self.user = User.objects.create_user(
+            email="user@example.com",
+            nickname="normal-user",
+            birth_date=datetime.date(1999, 1, 1),
+            password="Passw0rd!",
+        )
+        self.other_user = User.objects.create_user(
+            email="other@example.com",
+            nickname="other-user",
+            birth_date=datetime.date(1998, 1, 1),
+            password="Passw0rd!",
+        )
+        self.list_url = reverse("admin-user-list")
+        self.detail_url = reverse("admin-user-detail", args=[self.user.id])
+
+    def test_admin_user_list_returns_paginated_users_for_admin(self) -> None:
+        self.client.force_authenticate(user=self.admin_user)
+
+        response = self.client.get(self.list_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("count", response.json())
+        self.assertIn("results", response.json())
+        self.assertTrue(any(item["email"] == "user@example.com" for item in response.json()["results"]))
+
+    def test_admin_user_list_returns_403_for_non_admin(self) -> None:
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(self.list_url)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["code"], ErrorMessages.FORBIDDEN.name)
+
+    def test_admin_user_detail_returns_user_data_for_admin(self) -> None:
+        self.client.force_authenticate(user=self.admin_user)
+
+        response = self.client.get(self.detail_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["email"], "user@example.com")
+        self.assertEqual(response.json()["nickname"], "normal-user")
+
+    def test_admin_user_detail_returns_404_when_user_does_not_exist(self) -> None:
+        self.client.force_authenticate(user=self.admin_user)
+
+        response = self.client.get(reverse("admin-user-detail", args=[999999]))
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["code"], ErrorMessages.USER_NOT_FOUND.name)
+
+    def test_admin_user_status_update_changes_is_active(self) -> None:
+        self.client.force_authenticate(user=self.admin_user)
+
+        response = self.client.patch(
+            self.detail_url,
+            {
+                "is_active": False,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["is_active"])
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+
+    def test_admin_user_status_update_returns_403_for_non_admin(self) -> None:
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.patch(
+            self.detail_url,
+            {
+                "is_active": False,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["code"], ErrorMessages.FORBIDDEN.name)

--- a/apps/users/urls_admin.py
+++ b/apps/users/urls_admin.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from apps.users.views_admin import (
+    AdminUserDetailAPIView,
+    AdminUserListAPIView,
+)
+
+urlpatterns = [
+    path("", AdminUserListAPIView.as_view(), name="admin-user-list"),
+    path("<int:user_id>/", AdminUserDetailAPIView.as_view(), name="admin-user-detail"),
+]

--- a/apps/users/views_admin.py
+++ b/apps/users/views_admin.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast
-
 from django.db.models import QuerySet
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
@@ -11,8 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.core.exceptions.exception_handler import CustomAPIException
-from apps.core.exceptions.exception_message import ErrorMessages
+from apps.core.permissions import IsStaffAdmin
 from apps.core.serializers.error_serializer import ErrorResponseSerializer
 from apps.core.utils.pagination import PAGINATION_PARAMS, Pagination
 from apps.users.models.user import User
@@ -25,13 +22,6 @@ from apps.users.serializers.admin_user import (
 from apps.users.services import get_admin_user, list_admin_users, update_admin_user_status
 
 
-class AdminPermissionMixin:
-    def ensure_admin(self, request: Request) -> None:
-        user = cast(User, request.user)
-        if not user.is_staff:
-            raise CustomAPIException(ErrorMessages.FORBIDDEN)
-
-
 @extend_schema(
     tags=["admin"],
     summary="어드민 - 유저 목록 조회",
@@ -42,13 +32,12 @@ class AdminPermissionMixin:
         403: ErrorResponseSerializer,
     },
 )
-class AdminUserListAPIView(AdminPermissionMixin, ListAPIView):  # type: ignore[type-arg]
-    permission_classes = [IsAuthenticated]
+class AdminUserListAPIView(ListAPIView):  # type: ignore[type-arg]
+    permission_classes = [IsAuthenticated, IsStaffAdmin]
     serializer_class = AdminUserListItemSerializer
     pagination_class = Pagination
 
     def get_queryset(self) -> QuerySet[User]:
-        self.ensure_admin(self.request)
         return list_admin_users()
 
 
@@ -62,11 +51,10 @@ class AdminUserListAPIView(AdminPermissionMixin, ListAPIView):  # type: ignore[t
         404: OpenApiResponse(response=ErrorResponseSerializer, description="User not found"),
     },
 )
-class AdminUserDetailAPIView(AdminPermissionMixin, APIView):
-    permission_classes = [IsAuthenticated]
+class AdminUserDetailAPIView(APIView):
+    permission_classes = [IsAuthenticated, IsStaffAdmin]
 
     def get(self, request: Request, user_id: int) -> Response:
-        self.ensure_admin(request)
         user = get_admin_user(user_id=user_id)
         serializer = AdminUserDetailResponseSerializer(user)
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -83,13 +71,12 @@ class AdminUserDetailAPIView(AdminPermissionMixin, APIView):
         },
     )
     def patch(self, request: Request, user_id: int) -> Response:
-        self.ensure_admin(request)
         serializer = AdminUserStatusUpdateRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         user = update_admin_user_status(
             user_id=user_id,
-            is_active=cast(bool, serializer.validated_data["is_active"]),
+            is_active=bool(serializer.validated_data["is_active"]),
         )
         response_serializer = AdminUserDetailResponseSerializer(user)
         return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/apps/users/views_admin.py
+++ b/apps/users/views_admin.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import cast
+
+from django.db.models import QuerySet
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.generics import ListAPIView
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.core.serializers.error_serializer import ErrorResponseSerializer
+from apps.core.utils.pagination import PAGINATION_PARAMS, Pagination
+from apps.users.models.user import User
+from apps.users.serializers.admin_user import (
+    AdminUserDetailResponseSerializer,
+    AdminUserListItemSerializer,
+    AdminUserListResponseSerializer,
+    AdminUserStatusUpdateRequestSerializer,
+)
+from apps.users.services import get_admin_user, list_admin_users, update_admin_user_status
+
+
+class AdminPermissionMixin:
+    def ensure_admin(self, request: Request) -> None:
+        user = cast(User, request.user)
+        if not user.is_staff:
+            raise CustomAPIException(ErrorMessages.FORBIDDEN)
+
+
+@extend_schema(
+    tags=["admin"],
+    summary="어드민 - 유저 목록 조회",
+    parameters=PAGINATION_PARAMS,
+    responses={
+        200: AdminUserListResponseSerializer,
+        401: ErrorResponseSerializer,
+        403: ErrorResponseSerializer,
+    },
+)
+class AdminUserListAPIView(AdminPermissionMixin, ListAPIView):  # type: ignore[type-arg]
+    permission_classes = [IsAuthenticated]
+    serializer_class = AdminUserListItemSerializer
+    pagination_class = Pagination
+
+    def get_queryset(self) -> QuerySet[User]:
+        self.ensure_admin(self.request)
+        return list_admin_users()
+
+
+@extend_schema(
+    tags=["admin"],
+    summary="어드민 - 유저 상세 조회",
+    responses={
+        200: AdminUserDetailResponseSerializer,
+        401: ErrorResponseSerializer,
+        403: ErrorResponseSerializer,
+        404: OpenApiResponse(response=ErrorResponseSerializer, description="User not found"),
+    },
+)
+class AdminUserDetailAPIView(AdminPermissionMixin, APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request, user_id: int) -> Response:
+        self.ensure_admin(request)
+        user = get_admin_user(user_id=user_id)
+        serializer = AdminUserDetailResponseSerializer(user)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        tags=["admin"],
+        summary="어드민 - 유저 상태 변경",
+        request=AdminUserStatusUpdateRequestSerializer,
+        responses={
+            200: AdminUserDetailResponseSerializer,
+            401: ErrorResponseSerializer,
+            403: ErrorResponseSerializer,
+            404: OpenApiResponse(response=ErrorResponseSerializer, description="User not found"),
+        },
+    )
+    def patch(self, request: Request, user_id: int) -> Response:
+        self.ensure_admin(request)
+        serializer = AdminUserStatusUpdateRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        user = update_admin_user_status(
+            user_id=user_id,
+            is_active=cast(bool, serializer.validated_data["is_active"]),
+        )
+        response_serializer = AdminUserDetailResponseSerializer(user)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path("api/v1/admin/interaction-context-rules/", include("apps.interactions.urls_admin_context")),
     path("api/v1/recommendations/", include("apps.recommendations.urls")),
     path("api/v1/admin/recommendation-jobs/", include("apps.recommendations.urls_admin")),
+    path("api/v1/admin/users/", include("apps.users.urls_admin")),
     path("admin/", admin.site.urls),
     path("api/v1/", include("apps.users.urls")),
     path("api/v1/games/", include("apps.games.urls.games")),


### PR DESCRIPTION
## ✅ PR 요약
- 관리자 전용 유저 관리 API를 추가해 유저 목록 조회, 상세 조회, 상태 변경이 가능하도록 구현했습니다.

## 📄 상세 내용
- [x] `GET /api/v1/admin/users/` 엔드포인트를 추가해 관리자 유저 목록 조회를 지원했습니다.
- [x] `GET /api/v1/admin/users/{id}/` 엔드포인트를 추가해 특정 유저 상세 조회를 지원했습니다.
- [x] `PATCH /api/v1/admin/users/{id}/` 엔드포인트를 추가해 유저 활성 상태(`is_active`) 변경을 지원했습니다.
- [x] 관리자 권한(`is_staff`)이 없는 요청은 접근할 수 없도록 권한 검사를 적용했습니다.
- [x] users 도메인 내부에 `views_admin.py`, `urls_admin.py` 패턴으로 admin 기능을 추가해 기존 프로젝트 구조와 일관성을 맞췄습니다.
- [x] 목록/상세/상태 변경 및 권한 예외 케이스에 대한 테스트를 작성했습니다.
