### PR TITLE
[Feature/game-list-genre-name] 게임 목록 조회 - 장르 네임 매핑

### DIFF
--- a/apps/games/igdb/cache.py
+++ b/apps/games/igdb/cache.py
@@ -30,6 +30,24 @@ def _cache_key_search(params: dict[str, Any]) -> str:
     return f"igdb:search:{h}"
 
 
+def fetch_all_igdb_genres() -> dict[str, int]:
+    """IGDB에서 장르 목록을 가져와서 {장르이름: 장르ID} 매핑 반환"""
+    client = get_igdb_client()
+    raw_genres = client._post("genres", "fields id,name;limit 50;")
+    return {genre["name"]: genre["id"] for genre in raw_genres}
+
+
+def get_genre_id_by_name(name: str) -> int | None:
+    """
+    캐시에서 장르 이름 → IGDB 장르 ID 조회
+    캐시에 없으면 fetch_all_igdb_genres() 호출 후 캐시 저장
+    """
+    genre_map = cache.get("igdb:genre_map") or fetch_all_igdb_genres()
+    cache.set("igdb:genre_map", genre_map, 14 * 24 * 3600)
+    genre_id = genre_map.get(name)
+    return int(genre_id) if genre_id is not None else None
+
+
 def _resolve_genre_filters(genre_ids: list[int]) -> dict[str, list[int]]:
     """DB Genre PK 리스트 → IGDB 타입별 ID 분류"""
     from apps.games.models import Genre

--- a/apps/games/igdb/cache.py
+++ b/apps/games/igdb/cache.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from typing import Any
+from typing import Any, cast
 
+from django.conf import settings
 from django.core.cache import cache
 
 from apps.games.models import Platform
@@ -42,8 +43,17 @@ def get_genre_id_by_name(name: str) -> int | None:
     캐시에서 장르 이름 → IGDB 장르 ID 조회
     캐시에 없으면 fetch_all_igdb_genres() 호출 후 캐시 저장
     """
-    genre_map = cache.get("igdb:genre_map") or fetch_all_igdb_genres()
-    cache.set("igdb:genre_map", genre_map, 14 * 24 * 3600)
+    genre_map = cache.get(settings.IGDB_GENRE_MAP_CACHE_KEY)
+    if genre_map is None:
+        genre_map = fetch_all_igdb_genres()
+        cache.set(
+            settings.IGDB_GENRE_MAP_CACHE_KEY,
+            genre_map,
+            settings.IGDB_GENRE_MAP_CACHE_TTL,
+        )
+
+    genre_map = cast(dict[str, int], genre_map)
+
     genre_id = genre_map.get(name)
     return int(genre_id) if genre_id is not None else None
 

--- a/apps/games/serializers/game_list.py
+++ b/apps/games/serializers/game_list.py
@@ -26,6 +26,7 @@ class GameListQuerySerializer(serializers.Serializer[dict[str, Any]]):
     search = serializers.CharField(required=False)
     ordering = serializers.CharField(default="-rawg_rating", required=False)
     genre_ids = serializers.CharField(required=False)
+    genre_name = serializers.CharField(required=False)
     platform_ids = serializers.CharField(required=False)
     tag_ids = serializers.CharField(required=False)
     page = serializers.IntegerField(default=1, required=False)
@@ -39,6 +40,9 @@ class GameListQuerySerializer(serializers.Serializer[dict[str, Any]]):
 
     def validate_genre_ids(self, value: str | None) -> list[int]:
         return self._parse_int_list(value)
+
+    def validate_genre_name(self, value: str | None) -> str | None:
+        return value
 
     def validate_platform_ids(self, value: str | None) -> list[int]:
         return self._parse_int_list(value)

--- a/apps/games/services/game_list.py
+++ b/apps/games/services/game_list.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from apps.games.igdb import cache as igdb_cache
-from apps.games.igdb.client import get_igdb_client
 
 # IGDB 정렬 매핑: API 쿼리 파라미터 → IGDB sort 필드
 _ORDERING_MAP: dict[str, str] = {
@@ -43,7 +42,7 @@ class GameService:
         return results
 
     @staticmethod
-    def top_n_by_genre(genre_name: str, top_n: int = 10, sort: str = "-raw_rating") -> list[dict[str, Any]]:
+    def top_n_by_genre(genre_name: str, top_n: int = 10, sort: str = "-rawg_rating") -> list[dict[str, Any]]:
         igdb_sort = _ORDERING_MAP.get(sort, "rating desc")
 
         # 캐시에서 장르 이름 -> id 조회
@@ -51,6 +50,5 @@ class GameService:
         if not genre_id:
             return []
 
-        client = get_igdb_client()
-        results = client.search_games(genre_ids=[genre_id], sort=igdb_sort, limit=top_n)
+        results = igdb_cache.search_games(genre_ids=[genre_id], sort=igdb_sort, limit=top_n)
         return results

--- a/apps/games/services/game_list.py
+++ b/apps/games/services/game_list.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from apps.games.igdb import cache as igdb_cache
+from apps.games.igdb.client import get_igdb_client
 
 # IGDB 정렬 매핑: API 쿼리 파라미터 → IGDB sort 필드
 _ORDERING_MAP: dict[str, str] = {
@@ -39,4 +40,17 @@ class GameService:
             offset=offset,
         )
 
+        return results
+
+    @staticmethod
+    def top_n_by_genre(genre_name: str, top_n: int = 10, sort: str = "-raw_rating") -> list[dict[str, Any]]:
+        igdb_sort = _ORDERING_MAP.get(sort, "rating desc")
+
+        # 캐시에서 장르 이름 -> id 조회
+        genre_id = igdb_cache.get_genre_id_by_name(genre_name)
+        if not genre_id:
+            return []
+
+        client = get_igdb_client()
+        results = client.search_games(genre_ids=[genre_id], sort=igdb_sort, limit=top_n)
         return results

--- a/apps/games/tests/test_game_list.py
+++ b/apps/games/tests/test_game_list.py
@@ -1,5 +1,5 @@
 from datetime import date
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.urls import reverse
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from apps.core.exceptions.exception_message import ErrorMessages
+from apps.games.services.game_list import GameService
 
 User = get_user_model()
 
@@ -24,6 +25,24 @@ MOCK_GAME_LIST_ITEM = {
     "esrb_rating": "everyone",
     "age_rating_min": 0,
 }
+
+# Mock Top 10 games for genre_name test
+MOCK_TOP10_GAMES = [
+    {
+        "id": i,
+        "slug": f"test-game-{i}",
+        "name": f"Test Game {i}",
+        "released": "2025-01-01",
+        "thumbnail_img_url": f"https://images.igdb.com/igdb/image/upload/t_cover_big/co{i}wyy.jpg",
+        "rawg_rating": 5.5 - (i - 1) * 0.1,
+        "rawg_ratings_count": 100 + i * 10,
+        "genres": [{"id": 12, "name": "Action"}, {"id": 13, "name": "FPS"}],
+        "platforms": [{"id": 6, "name": "PC"}],
+        "esrb_rating": "everyone",
+        "age_rating_min": 0,
+    }
+    for i in range(1, 11)
+]
 
 
 class GameListViewTests(APITestCase):
@@ -52,6 +71,23 @@ class GameListViewTests(APITestCase):
         game_data = response.data["results"][0]
         self.assertEqual(game_data["name"], "Test Game")
         self.assertEqual(game_data["genres"][0]["name"], "Action")
+
+    @patch("apps.games.services.game_list.igdb_cache.search_games")
+    def test_game_list_search_and_ordering(self, mock_search: MagicMock) -> None:
+        """검색어 필터 및 정렬 적용"""
+        mock_search.return_value = [MOCK_GAME_LIST_ITEM]
+
+        self.client.force_authenticate(user=self.user)
+        # 검색어 + 내림차순
+        response = self.client.get(self.url, {"search": "Test", "ordering": "-rawg_rating"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+
+        # 검색어 존재하지만 결과 없음
+        mock_search.return_value = []
+        response = self.client.get(self.url, {"search": "NoMatch"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 0)
 
     def test_invalid_ordering(self) -> None:
         """잘못된 ordering 값"""
@@ -84,3 +120,43 @@ class GameListViewTests(APITestCase):
         response = self.client.get(self.url, {"search": "NoMatch"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 0)
+
+    @patch("apps.games.services.game_list.get_igdb_client")
+    @patch("apps.games.services.game_list.igdb_cache.get_genre_id_by_name")
+    def test_top_n_by_genre_service_real(self, mock_get_genre_id: MagicMock, mock_get_client: MagicMock) -> None:
+        """top_n_by_genre 내부 분기와 검색까지 실제 실행"""
+        # ------------------
+        # 장르 존재 시
+        # ------------------
+        mock_get_genre_id.return_value = 12
+        mock_client_instance = MagicMock()
+        mock_get_client.return_value = mock_client_instance
+        mock_client_instance.search_games.return_value = MOCK_TOP10_GAMES
+
+        result = GameService.top_n_by_genre("Action")
+        self.assertEqual(len(result), 10)
+        self.assertEqual(result[0]["rawg_rating"], 5.5)
+        self.assertEqual(result[-1]["rawg_rating"], 4.6)
+
+        # ------------------
+        # 장르 미존재 시
+        # ------------------
+        mock_get_genre_id.return_value = None
+        result = GameService.top_n_by_genre("NonExistent")
+        self.assertEqual(result, [])
+
+    @patch("apps.games.services.game_list.GameService.top_n_by_genre")
+    def test_top_n_by_genre_api_mocked(self, mock_top_n: MagicMock) -> None:
+        """API 레이어 테스트: top_n_by_genre patch"""
+        mock_top_n.return_value = MOCK_TOP10_GAMES
+        self.client.force_authenticate(user=self.user)
+        resp = self.client.get(self.url, {"genre_name": "Action"})
+        self.assertEqual(len(resp.data["results"]), 10)
+        self.assertEqual(resp.data["results"][0]["rawg_rating"], 5.5)
+        self.assertIsNone(resp.data["next"])
+        self.assertIsNone(resp.data["previous"])
+
+        # 빈 리스트 반환
+        mock_top_n.return_value = []
+        resp = self.client.get(self.url, {"genre_name": "NonExistent"})
+        self.assertEqual(resp.data["results"], [])

--- a/apps/games/tests/test_game_list.py
+++ b/apps/games/tests/test_game_list.py
@@ -72,23 +72,6 @@ class GameListViewTests(APITestCase):
         self.assertEqual(game_data["name"], "Test Game")
         self.assertEqual(game_data["genres"][0]["name"], "Action")
 
-    @patch("apps.games.services.game_list.igdb_cache.search_games")
-    def test_game_list_search_and_ordering(self, mock_search: MagicMock) -> None:
-        """검색어 필터 및 정렬 적용"""
-        mock_search.return_value = [MOCK_GAME_LIST_ITEM]
-
-        self.client.force_authenticate(user=self.user)
-        # 검색어 + 내림차순
-        response = self.client.get(self.url, {"search": "Test", "ordering": "-rawg_rating"})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["results"]), 1)
-
-        # 검색어 존재하지만 결과 없음
-        mock_search.return_value = []
-        response = self.client.get(self.url, {"search": "NoMatch"})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["results"]), 0)
-
     def test_invalid_ordering(self) -> None:
         """잘못된 ordering 값"""
         self.client.force_authenticate(user=self.user)
@@ -106,43 +89,55 @@ class GameListViewTests(APITestCase):
         self.assertEqual(response.data["message"], ErrorMessages.INVALID_QUERY_PARAM.message)
 
     @patch("apps.games.services.game_list.igdb_cache.search_games")
-    def test_search_filter(self, mock_search: object) -> None:
-        """검색어 필터 적용"""
-        mock_search.return_value = [MOCK_GAME_LIST_ITEM]  # type: ignore[attr-defined]
-
+    def test_search_and_ordering(self, mock_search: MagicMock) -> None:
+        """검색 + 정렬 통합 테스트"""
         self.client.force_authenticate(user=self.user)
-        response = self.client.get(self.url, {"search": "Test"})
+
+        # 검색 결과 있음
+        mock_search.return_value = [MOCK_GAME_LIST_ITEM]
+
+        response = self.client.get(
+            self.url,
+            {"search": "Test", "ordering": "-rawg_rating"},
+        )
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 1)
 
-        # Second search returns empty
-        mock_search.return_value = []  # type: ignore[attr-defined]
+        game_data = response.data["results"][0]
+        self.assertEqual(game_data["name"], "Test Game")
+
+        # 검색 결과 없음
+        mock_search.return_value = []
+
         response = self.client.get(self.url, {"search": "NoMatch"})
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 0)
 
-    @patch("apps.games.services.game_list.get_igdb_client")
+    @patch("apps.games.services.game_list.igdb_cache.search_games")
     @patch("apps.games.services.game_list.igdb_cache.get_genre_id_by_name")
-    def test_top_n_by_genre_service_real(self, mock_get_genre_id: MagicMock, mock_get_client: MagicMock) -> None:
+    def test_top_n_by_genre_service_real(self, mock_get_genre_id: MagicMock, mock_search: MagicMock) -> None:
         """top_n_by_genre 내부 분기와 검색까지 실제 실행"""
         # ------------------
-        # 장르 존재 시
+        # 장르 존재
         # ------------------
         mock_get_genre_id.return_value = 12
-        mock_client_instance = MagicMock()
-        mock_get_client.return_value = mock_client_instance
-        mock_client_instance.search_games.return_value = MOCK_TOP10_GAMES
+        mock_search.return_value = MOCK_TOP10_GAMES
 
         result = GameService.top_n_by_genre("Action")
+
         self.assertEqual(len(result), 10)
         self.assertEqual(result[0]["rawg_rating"], 5.5)
-        self.assertEqual(result[-1]["rawg_rating"], 4.6)
+        self.assertAlmostEqual(result[-1]["rawg_rating"], 4.6)
 
         # ------------------
-        # 장르 미존재 시
+        # 장르 없음
         # ------------------
         mock_get_genre_id.return_value = None
+
         result = GameService.top_n_by_genre("NonExistent")
+
         self.assertEqual(result, [])
 
     @patch("apps.games.services.game_list.GameService.top_n_by_genre")
@@ -152,7 +147,7 @@ class GameListViewTests(APITestCase):
         self.client.force_authenticate(user=self.user)
         resp = self.client.get(self.url, {"genre_name": "Action"})
         self.assertEqual(len(resp.data["results"]), 10)
-        self.assertEqual(resp.data["results"][0]["rawg_rating"], 5.5)
+        self.assertEqual(resp.data["results"][0]["rawg_rating"], "5.50")
         self.assertIsNone(resp.data["next"])
         self.assertIsNone(resp.data["previous"])
 

--- a/apps/games/views/game_list.py
+++ b/apps/games/views/game_list.py
@@ -99,4 +99,6 @@ class GameListView(APIView):
             "results": items,
         }
 
-        return Response(response_data, status=status.HTTP_200_OK)
+        serializer = GameListResponseSerializer(response_data)
+
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/games/views/game_list.py
+++ b/apps/games/views/game_list.py
@@ -67,24 +67,31 @@ class GameListView(APIView):
         page = data.get("page", 1)
         page_size = data.get("page_size", 20)
 
-        results = GameService.list_games(
-            search=data.get("search"),
-            genre_ids=data.get("genre_ids"),
-            platform_ids=data.get("platform_ids"),
-            tag_ids=data.get("tag_ids"),
-            ordering=data.get("ordering"),
-            page=page,
-            page_size=page_size,
-        )
+        genre_name = data.get("genre_name")
 
-        # has_next 판단: page_size+1 개를 요청했으므로
-        has_next = len(results) > page_size
-        items = results[:page_size]
+        if genre_name:
+            items = GameService.top_n_by_genre(genre_name)
+            next_url = None
+            previous_url = None
+        else:
+            results = GameService.list_games(
+                search=data.get("search"),
+                genre_ids=data.get("genre_ids"),
+                platform_ids=data.get("platform_ids"),
+                tag_ids=data.get("tag_ids"),
+                ordering=data.get("ordering"),
+                page=page,
+                page_size=page_size,
+            )
 
-        # next/previous URL 생성
-        path = request.build_absolute_uri(request.path)
-        next_url = f"{path}?page={page + 1}&page_size={page_size}" if has_next else None
-        previous_url = f"{path}?page={page - 1}&page_size={page_size}" if page > 1 else None
+            # has_next 판단: page_size+1 개를 요청했으므로
+            has_next = len(results) > page_size
+            items = results[:page_size]
+
+            # next/previous URL 생성
+            path = request.build_absolute_uri(request.path)
+            next_url = f"{path}?page={page + 1}&page_size={page_size}" if has_next else None
+            previous_url = f"{path}?page={page - 1}&page_size={page_size}" if page > 1 else None
 
         response_data = {
             "next": next_url,

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -136,6 +136,10 @@ GENRES_CACHE_TTL = 60 * 60  # 캐싱 TTL (초 단위) - 1시간
 PLATFORMS_CACHE_KEY = "platforms:all"
 PLATFORMS_CACHE_TTL = 60 * 60
 
+# IGDB 장르 매핑 캐싱
+IGDB_GENRE_MAP_CACHE_KEY = "igdb:genre_map"
+IGDB_GENRE_MAP_CACHE_TTL = 14 * 24 * 3600
+
 # Celery (RAWG 동기화, 추천 재생성 비동기 처리)
 CELERY_BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/2"
 CELERY_RESULT_BACKEND = f"redis://{REDIS_HOST}:{REDIS_PORT}/2"


### PR DESCRIPTION
## ✅ PR 요약
- 장르 이름으로 IGDB에서 ID 매핑 -> 홈 화면에 각 장르 top 10의 게임을 보여줌

## 📄 상세 내용
- [x] igdb/cache.py에 fetch_all_igdb_genres(), get_genre_id_by_name 추가
- [x] GameListQuerySerializer에 genre_name 필드 추가
- [x] service에 top_n_by_genre 추가
- [x] view에 genre_name 값이 있을 때의 로직 추가
- [x] test에 top10 mock데이터 추가 및 테스트 추가
## 🧪 테스트
- [x] 로컬에서 확인했습니다.

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.