### PR TITLE
[Feature/auth/social-callback-redirect] 소셜 로그인 콜백 리다이렉트 처리 추가

### DIFF
--- a/apps/users/tests/test_discord_callback.py
+++ b/apps/users/tests/test_discord_callback.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from rest_framework.test import APIClient
 
@@ -37,17 +37,32 @@ class DiscordCallbackAPITestCase(TestCase):
             "is_new_user": True,
         }
 
-        response = self.client.get(
-            self.url,
-            {
-                "code": "test-code",
-                "state": "valid-state",
-            },
-        )
+        response = self.client.get(self.url, {"code": "test-code", "state": "valid-state"})
 
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.json()["access_token"], "test-access-token")
-        self.assertEqual(response.json()["token_type"], "Bearer")
-        self.assertEqual(response.json()["expires_in"], 3600)
-        self.assertEqual(response.json()["is_new_user"], True)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "http://testserver/onboarding/")
+        self.assertEqual(response.cookies["refresh_token"].value, "test-refresh-token")
+
+    @override_settings(
+        FRONTEND_BASE_URL="https://frontend.example.com",
+        SOCIAL_LOGIN_SUCCESS_URL="https://frontend.example.com",
+        SOCIAL_LOGIN_ONBOARDING_URL="https://frontend.example.com/onboarding",
+    )
+    @patch("apps.users.views.social_auth.handle_discord_callback")
+    def test_discord_callback_redirects_existing_user_to_frontend_home(
+        self,
+        mock_handle_discord_callback: MagicMock,
+    ) -> None:
+        mock_handle_discord_callback.return_value = {
+            "access_token": "test-access-token",
+            "refresh_token": "test-refresh-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "is_new_user": False,
+        }
+
+        response = self.client.get(self.url, {"code": "test-code", "state": "valid-state"})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "https://frontend.example.com")
         self.assertEqual(response.cookies["refresh_token"].value, "test-refresh-token")

--- a/apps/users/tests/test_kakao_callback.py
+++ b/apps/users/tests/test_kakao_callback.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from rest_framework.test import APIClient
 
 from apps.core.exceptions.exception_message import ErrorMessages
@@ -36,17 +36,32 @@ class KakaoCallbackAPITestCase(TestCase):
             "is_new_user": True,
         }
 
-        response = self.client.get(
-            self.url,
-            {
-                "code": "test-code",
-                "state": "valid-state",
-            },
-        )
+        response = self.client.get(self.url, {"code": "test-code", "state": "valid-state"})
 
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.json()["access_token"], "test-access-token")
-        self.assertEqual(response.json()["token_type"], "Bearer")
-        self.assertEqual(response.json()["expires_in"], 3600)
-        self.assertEqual(response.json()["is_new_user"], True)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "http://testserver/onboarding/")
+        self.assertEqual(response.cookies["refresh_token"].value, "test-refresh-token")
+
+    @override_settings(
+        FRONTEND_BASE_URL="https://frontend.example.com",
+        SOCIAL_LOGIN_SUCCESS_URL="https://frontend.example.com",
+        SOCIAL_LOGIN_ONBOARDING_URL="https://frontend.example.com/onboarding",
+    )
+    @patch("apps.users.views.social_auth.handle_kakao_callback")
+    def test_kakao_callback_redirects_existing_user_to_frontend_home(
+        self,
+        mock_handle_kakao_callback: MagicMock,
+    ) -> None:
+        mock_handle_kakao_callback.return_value = {
+            "access_token": "test-access-token",
+            "refresh_token": "test-refresh-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "is_new_user": False,
+        }
+
+        response = self.client.get(self.url, {"code": "test-code", "state": "valid-state"})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "https://frontend.example.com")
         self.assertEqual(response.cookies["refresh_token"].value, "test-refresh-token")

--- a/apps/users/views/social_auth.py
+++ b/apps/users/views/social_auth.py
@@ -55,12 +55,11 @@ class SocialCallbackAPIView(APIView):
         request: Request,
         *,
         result: dict[str, object],
-    ) -> Response | HttpResponseRedirect:
+    ) -> HttpResponseRedirect:
         refresh_token = cast(str, result.pop("refresh_token"))
         is_new_user = cast(bool, result["is_new_user"])
-        status_code = 201 if is_new_user else 200
-
-        response = Response(SocialLoginResponseSerializer(result).data, status=status_code)
+        redirect_url = _resolve_social_redirect_url(request, is_new_user=is_new_user)
+        response = redirect(redirect_url)
         response.set_cookie(
             key="refresh_token",
             value=refresh_token,
@@ -109,24 +108,6 @@ class SocialCallbackAPIView(APIView):
 class KakaoCallbackAPIView(SocialCallbackAPIView):
     def handle_callback(self, *, code: str, state: str) -> dict[str, object]:
         return handle_kakao_callback(code=code, state=state)
-
-    def build_success_response(
-        self,
-        request: Request,
-        *,
-        result: dict[str, object],
-    ) -> HttpResponseRedirect:
-        refresh_token = cast(str, result.pop("refresh_token"))
-        is_new_user = cast(bool, result["is_new_user"])
-        redirect_url = _resolve_social_redirect_url(request, is_new_user=is_new_user)
-        response = redirect(redirect_url)
-        response.set_cookie(
-            key="refresh_token",
-            value=refresh_token,
-            httponly=True,
-            samesite="Lax",
-        )
-        return response
 
 
 @extend_schema(
@@ -178,21 +159,3 @@ class DiscordLoginAPIView(APIView):
 class DiscordCallbackAPIView(SocialCallbackAPIView):
     def handle_callback(self, *, code: str, state: str) -> dict[str, object]:
         return handle_discord_callback(code=code, state=state)
-
-    def build_success_response(
-        self,
-        request: Request,
-        *,
-        result: dict[str, object],
-    ) -> HttpResponseRedirect:
-        refresh_token = cast(str, result.pop("refresh_token"))
-        is_new_user = cast(bool, result["is_new_user"])
-        redirect_url = _resolve_social_redirect_url(request, is_new_user=is_new_user)
-        response = redirect(redirect_url)
-        response.set_cookie(
-            key="refresh_token",
-            value=refresh_token,
-            httponly=True,
-            samesite="Lax",
-        )
-        return response

--- a/apps/users/views/social_auth.py
+++ b/apps/users/views/social_auth.py
@@ -1,25 +1,30 @@
 from typing import cast
+from urllib.parse import urljoin
 
+from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
-from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.core.serializers.error_serializer import ErrorResponseSerializer
-from apps.users.serializers.social_auth import (
-    SocialCallbackRequestSerializer,
-    SocialLoginResponseSerializer,
-)
+from apps.users.serializers.social_auth import SocialCallbackRequestSerializer, SocialLoginResponseSerializer
 from apps.users.services import (
     build_discord_login_url,
     build_kakao_login_url,
     handle_discord_callback,
     handle_kakao_callback,
 )
+
+
+def _resolve_social_redirect_url(request: Request, *, is_new_user: bool) -> str:
+    base_url = settings.FRONTEND_BASE_URL or request.build_absolute_uri("/")
+    success_url = settings.SOCIAL_LOGIN_SUCCESS_URL or base_url
+    onboarding_url = settings.SOCIAL_LOGIN_ONBOARDING_URL or urljoin(base_url.rstrip("/") + "/", "onboarding/")
+    return onboarding_url if is_new_user else success_url
 
 
 @extend_schema(
@@ -45,15 +50,15 @@ class SocialCallbackAPIView(APIView):
     def handle_callback(self, *, code: str, state: str) -> dict[str, object]:
         raise NotImplementedError
 
-    def get(self, request: Request) -> Response:
-        serializer = SocialCallbackRequestSerializer(data=request.query_params)
-        serializer.is_valid(raise_exception=True)
-
-        result = self.handle_callback(**serializer.validated_data)
-
+    def build_success_response(
+        self,
+        request: Request,
+        *,
+        result: dict[str, object],
+    ) -> Response | HttpResponseRedirect:
         refresh_token = cast(str, result.pop("refresh_token"))
-        is_new_user = result["is_new_user"]
-        status_code = status.HTTP_201_CREATED if is_new_user else status.HTTP_200_OK
+        is_new_user = cast(bool, result["is_new_user"])
+        status_code = 201 if is_new_user else 200
 
         response = Response(SocialLoginResponseSerializer(result).data, status=status_code)
         response.set_cookie(
@@ -63,6 +68,13 @@ class SocialCallbackAPIView(APIView):
             samesite="Lax",
         )
         return response
+
+    def get(self, request: Request) -> Response | HttpResponseRedirect:
+        serializer = SocialCallbackRequestSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+
+        result = self.handle_callback(**serializer.validated_data)
+        return self.build_success_response(request, result=result)
 
 
 @extend_schema(
@@ -97,6 +109,24 @@ class SocialCallbackAPIView(APIView):
 class KakaoCallbackAPIView(SocialCallbackAPIView):
     def handle_callback(self, *, code: str, state: str) -> dict[str, object]:
         return handle_kakao_callback(code=code, state=state)
+
+    def build_success_response(
+        self,
+        request: Request,
+        *,
+        result: dict[str, object],
+    ) -> HttpResponseRedirect:
+        refresh_token = cast(str, result.pop("refresh_token"))
+        is_new_user = cast(bool, result["is_new_user"])
+        redirect_url = _resolve_social_redirect_url(request, is_new_user=is_new_user)
+        response = redirect(redirect_url)
+        response.set_cookie(
+            key="refresh_token",
+            value=refresh_token,
+            httponly=True,
+            samesite="Lax",
+        )
+        return response
 
 
 @extend_schema(
@@ -148,3 +178,21 @@ class DiscordLoginAPIView(APIView):
 class DiscordCallbackAPIView(SocialCallbackAPIView):
     def handle_callback(self, *, code: str, state: str) -> dict[str, object]:
         return handle_discord_callback(code=code, state=state)
+
+    def build_success_response(
+        self,
+        request: Request,
+        *,
+        result: dict[str, object],
+    ) -> HttpResponseRedirect:
+        refresh_token = cast(str, result.pop("refresh_token"))
+        is_new_user = cast(bool, result["is_new_user"])
+        redirect_url = _resolve_social_redirect_url(request, is_new_user=is_new_user)
+        response = redirect(redirect_url)
+        response.set_cookie(
+            key="refresh_token",
+            value=refresh_token,
+            httponly=True,
+            samesite="Lax",
+        )
+        return response

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -22,6 +22,9 @@ DISCORD_REDIRECT_URI = os.getenv("DISCORD_REDIRECT_URI")
 DISCORD_AUTHORIZE_URL = "https://discord.com/oauth2/authorize"
 DISCORD_TOKEN_URL = "https://discord.com/api/v10/oauth2/token"
 DISCORD_USER_INFO_URL = "https://discord.com/api/v10/users/@me"
+FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL")
+SOCIAL_LOGIN_SUCCESS_URL = os.getenv("SOCIAL_LOGIN_SUCCESS_URL")
+SOCIAL_LOGIN_ONBOARDING_URL = os.getenv("SOCIAL_LOGIN_ONBOARDING_URL")
 BBATON_AUTHORIZE_URL = os.getenv("BBATON_AUTHORIZE_URL")
 BBATON_TOKEN_URL = os.getenv("BBATON_TOKEN_URL")
 BBATON_USER_INFO_URL = os.getenv("BBATON_USER_INFO_URL")
@@ -36,10 +39,8 @@ EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True") == "True"
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", EMAIL_HOST_USER)
 
-# Custom User Model
 AUTH_USER_MODEL = "users.User"
 
-# Application definition
 DJANGO_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
@@ -52,13 +53,12 @@ DJANGO_APPS = [
 THIRD_PARTY_APPS = [
     "rest_framework",
     "rest_framework_simplejwt",
-    "rest_framework_simplejwt.token_blacklist",  # 로그아웃 시 refresh 토큰 블랙리스트
+    "rest_framework_simplejwt.token_blacklist",
     "corsheaders",
     "drf_spectacular",
     "django_filters",
 ]
 
-# 추가한 도메인별 앱
 CUSTOM_APPS: list[str] = [
     "apps.users.apps.UsersConfig",
     "apps.games.apps.GamesConfig",
@@ -100,8 +100,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "config.wsgi.application"
 
-
-# Database
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
@@ -117,7 +115,6 @@ for field, value in DATABASES["default"].items():
     if field != "ENGINE" and not value:
         raise ValueError(f"Database config '{field}' is not set")
 
-# Redis
 REDIS_HOST = os.getenv("REDIS_HOST")
 REDIS_PORT = os.getenv("REDIS_PORT")
 
@@ -127,26 +124,22 @@ if not REDIS_PORT or not REDIS_HOST:
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/1",  # Redis 서버주소
+        "LOCATION": f"redis://{REDIS_HOST}:{REDIS_PORT}/1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
     }
 }
 
-# 장르 캐싱
-GENRES_CACHE_KEY = "genres:all"  # 캐싱 키
-GENRES_CACHE_TTL = 60 * 60  # 캐싱 TTL (초 단위) - 1시간
+GENRES_CACHE_KEY = "genres:all"
+GENRES_CACHE_TTL = 60 * 60
 
-# 플랫폼 캐싱
 PLATFORMS_CACHE_KEY = "platforms:all"
 PLATFORMS_CACHE_TTL = 60 * 60
 
-# IGDB 장르 매핑 캐싱
 IGDB_GENRE_MAP_CACHE_KEY = "igdb:genre_map"
 IGDB_GENRE_MAP_CACHE_TTL = 14 * 24 * 3600
 
-# Celery (RAWG 동기화, 추천 재생성 비동기 처리)
 CELERY_BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/2"
 CELERY_RESULT_BACKEND = f"redis://{REDIS_HOST}:{REDIS_PORT}/2"
 CELERY_ACCEPT_CONTENT = ["json"]
@@ -154,7 +147,6 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = "Asia/Seoul"
 
-# Password validation
 AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
@@ -170,7 +162,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-# djangorestframework-simplejwt 관련 설정
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(hours=1),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
@@ -183,16 +174,13 @@ SIMPLE_JWT = {
     "USER_ID_CLAIM": "user_id",
 }
 
-# Internationalization
 LANGUAGE_CODE = "ko-KR"
 TIME_ZONE = "Asia/Seoul"
 USE_I18N = True
 USE_TZ = True
 
-# Default primary key field type
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-# CORS (환경별 settings에서 CORS_ALLOWED_ORIGINS 설정)
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOW_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
 CORS_ALLOW_HEADERS = [
@@ -205,7 +193,6 @@ CORS_ALLOW_HEADERS = [
     "x-requested-with",
 ]
 
-# drf 관련 설정
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticatedOrReadOnly",),
@@ -216,7 +203,6 @@ REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "apps.core.exceptions.exception_handler.custom_exception_handler",
 }
 
-# drf-spectacular 관련 설정
 SPECTACULAR_SETTINGS = {
     "TITLE": "게임 추천 서비스 Backend API",
     "DESCRIPTION": "사용자 취향 기반 게임 추천 웹사이트 개발을 위한 API입니다.",
@@ -226,10 +212,10 @@ SPECTACULAR_SETTINGS = {
     "SWAGGER_UI_SETTINGS": {
         "dom_id": "#swagger-ui",
         "layout": "BaseLayout",
-        "deepLinking": True,  # API를 클릭할때 마다 SwaggerUI의 url이 변경됩니다. (특정 API url 공유시 유용하기때문에 True설정을 사용합니다)
-        "persistAuthorization": True,  # True 이면 SwaggerUI상 Authorize에 입력된 정보가 새로고침을 하더라도 초기화되지 않습니다.
-        "displayOperationId": True,  # True이면 API의 urlId 값을 노출합니다. 대체로 DRF api name둘과 일치하기때문에 api를 찾을때 유용합니다.
-        "filter": True,  # True 이면 Swagger UI에서 'Filter by Tag' 검색이 가능합니다
+        "deepLinking": True,
+        "persistAuthorization": True,
+        "displayOperationId": True,
+        "filter": True,
     },
     "SERVE_PERMISSIONS": ["rest_framework.permissions.AllowAny"],
     "SECURITY": [
@@ -243,18 +229,10 @@ SPECTACULAR_SETTINGS = {
     ],
 }
 
-
-# Game data sync
-# RAWG API
 RAWG_API_KEY = os.getenv("RAWG_API_KEY")
-# if not RAWG_API_KEY:
-#     raise ValueError("RAWG_API_KEY must be set")
-
-# IGDB API
 IGDB_CLIENT_ID = os.getenv("IGDB_CLIENT_ID")
 IGDB_CLIENT_SECRET = os.getenv("IGDB_CLIENT_SECRET")
 
-# Celery Beat 스케줄
 from celery.schedules import crontab  # noqa: E402
 
 ACCOUNT_DELETION_RETENTION_DAYS = int(os.getenv("ACCOUNT_DELETION_RETENTION_DAYS", "7"))
@@ -270,9 +248,7 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 
-CELERY_TASK_ACKS_LATE = True  # 실행 완료 후 ack → 워커 재시작 시 재실행 보장
-CELERY_WORKER_PREFETCH_MULTIPLIER = 1  # 무거운 sync task는 1개씩
+CELERY_TASK_ACKS_LATE = True
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 
-
-# 최근 검색 내역 Redis 보관 개수
 SEARCH_HISTORY_MAX_SIZE = int(os.getenv("SEARCH_HISTORY_MAX_SIZE", "20"))


### PR DESCRIPTION
## ✅ PR 요약
- 카카오/디스코드 소셜 로그인 콜백 성공 후 JSON 응답 대신 프론트 페이지로 리다이렉트되도록 수정했습니다.

## 📄 상세 내용
- [x] `GET /api/v1/auth/kakao/callback/` 성공 시 신규 유저는 온보딩 페이지로, 기존 유저는 메인 페이지로 리다이렉트되도록 변경했습니다.
- [x] `GET /api/v1/auth/discord/callback/`도 동일하게 신규 유저는 온보딩 페이지, 기존 유저는 메인 페이지로 리다이렉트되도록 변경했습니다.
- [x] 카카오/디스코드 콜백 처리 후 `refresh_token` 쿠키 설정은 기존과 동일하게 유지했습니다.
- [x] 프론트 리다이렉트 경로를 위해 `FRONTEND_BASE_URL`, `SOCIAL_LOGIN_SUCCESS_URL`, `SOCIAL_LOGIN_ONBOARDING_URL` 설정을 추가했습니다.
- [x] 카카오/디스코드 콜백 테스트를 JSON 응답 기준에서 리다이렉트 기준으로 수정했습니다.
- [x] 신규 유저/기존 유저 분기 리다이렉트 테스트를 추가했습니다.