### PR TITLE
[Feature/user/ProfileImage] 프로필 이미지 presigned URL 발급 API 추가

### DIFF
--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -45,5 +45,21 @@ class UserPasswordChangeRequestSerializer(serializers.Serializer[dict[str, objec
     new_password = serializers.CharField(write_only=True)
 
 
+class UserProfileImageUploadRequestSerializer(serializers.Serializer[dict[str, object]]):
+    file_name = serializers.CharField()
+    content_type = serializers.CharField()
+    file_size = serializers.IntegerField(min_value=1)
+
+
+class UserProfileImageUploadResponseSerializer(serializers.Serializer[dict[str, object]]):
+    upload_url = serializers.URLField()
+    profile_img_url = serializers.URLField(allow_null=True)
+    expires_in = serializers.IntegerField()
+
+
+class UserProfileImageResponseSerializer(serializers.Serializer[dict[str, object]]):
+    profile_img_url = serializers.URLField(allow_null=True)
+
+
 class UserMeDeleteResponseSerializer(serializers.Serializer[dict[str, object]]):
     message = serializers.CharField()

--- a/apps/users/services/__init__.py
+++ b/apps/users/services/__init__.py
@@ -22,14 +22,24 @@ from .social_auth_service import (
     handle_discord_callback,
     handle_kakao_callback,
 )
-from .user_me_service import change_user_password, delete_user_me, get_user_me, update_user_me, verify_user_password
+from .user_me_service import (
+    change_user_password,
+    create_user_profile_image_upload_url,
+    delete_user_me,
+    delete_user_profile_image,
+    get_user_me,
+    update_user_me,
+    verify_user_password,
+)
 
 __all__ = [
     "authenticate_user",
     "change_user_password",
     "clear_recent_searches",
+    "create_user_profile_image_upload_url",
     "delete_recent_search_keyword",
     "delete_user_me",
+    "delete_user_profile_image",
     "get_admin_dashboard_summary",
     "get_admin_user",
     "get_active_user_or_deactivated",

--- a/apps/users/services/user_me_service.py
+++ b/apps/users/services/user_me_service.py
@@ -15,7 +15,7 @@ from apps.users.models.user import User
 from apps.users.services.auth_service import get_active_user_or_deactivated, revoke_all_refresh_tokens
 
 PROFILE_IMAGE_MAX_SIZE_BYTES = 5 * 1024 * 1024
-PROFILE_IMAGE_UPLOAD_DIR = "profile-images"
+PROFILE_IMAGE_UPLOAD_DIR = "images/profile"
 ALLOWED_PROFILE_IMAGE_EXTENSIONS = {"jpg", "jpeg", "png", "webp"}
 ALLOWED_PROFILE_IMAGE_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
 
@@ -116,8 +116,6 @@ def _get_s3_client() -> Any:
 
     return boto3.client(
         "s3",
-        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
         region_name=settings.AWS_S3_REGION_NAME,
     )
 

--- a/apps/users/services/user_me_service.py
+++ b/apps/users/services/user_me_service.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import uuid
 from datetime import date
+from typing import Any
 
+from django.conf import settings
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
@@ -10,6 +13,11 @@ from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
 from apps.users.services.auth_service import get_active_user_or_deactivated, revoke_all_refresh_tokens
+
+PROFILE_IMAGE_MAX_SIZE_BYTES = 5 * 1024 * 1024
+PROFILE_IMAGE_UPLOAD_DIR = "profile-images"
+ALLOWED_PROFILE_IMAGE_EXTENSIONS = {"jpg", "jpeg", "png", "webp"}
+ALLOWED_PROFILE_IMAGE_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
 
 
 def get_user_me(user: User) -> User:
@@ -94,3 +102,104 @@ def change_user_password(user: User, *, new_password: str) -> None:
     user.set_password(new_password)
     user.save(update_fields=["password", "updated_at"])
     revoke_all_refresh_tokens(user)
+
+
+def _get_s3_client() -> Any:
+    s3_client = getattr(settings, "S3_CLIENT", None)
+    if s3_client is not None:
+        return s3_client
+
+    try:
+        import boto3
+    except ImportError as err:
+        raise CustomAPIException(ErrorMessages.SERVER_ERROR) from err
+
+    return boto3.client(
+        "s3",
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        region_name=settings.AWS_S3_REGION_NAME,
+    )
+
+
+def _ensure_profile_image_storage_config() -> None:
+    required_settings = (
+        settings.AWS_STORAGE_BUCKET_NAME,
+        settings.AWS_S3_PUBLIC_BASE_URL,
+        settings.AWS_S3_REGION_NAME,
+    )
+    if not all(required_settings):
+        raise CustomAPIException(ErrorMessages.SERVER_ERROR)
+
+
+def _build_profile_image_url(object_key: str) -> str:
+    public_base_url = settings.AWS_S3_PUBLIC_BASE_URL
+    if public_base_url is None:
+        raise CustomAPIException(ErrorMessages.SERVER_ERROR)
+    return f"{public_base_url.rstrip('/')}/{object_key}"
+
+
+def _get_profile_image_object_key(profile_img_url: str | None) -> str | None:
+    if not profile_img_url or not settings.AWS_S3_PUBLIC_BASE_URL:
+        return None
+
+    prefix = f"{settings.AWS_S3_PUBLIC_BASE_URL.rstrip('/')}/"
+    if profile_img_url.startswith(prefix):
+        return profile_img_url.removeprefix(prefix)
+    return None
+
+
+def create_user_profile_image_upload_url(
+    user: User,
+    *,
+    file_name: str,
+    content_type: str,
+    file_size: int,
+) -> dict[str, object]:
+    user = get_user_me(user)
+    _ensure_profile_image_storage_config()
+
+    extension = file_name.rsplit(".", 1)[-1].lower() if "." in file_name else ""
+    if extension not in ALLOWED_PROFILE_IMAGE_EXTENSIONS or content_type not in ALLOWED_PROFILE_IMAGE_CONTENT_TYPES:
+        raise CustomAPIException(ErrorMessages.INVALID_FILE_TYPE)
+
+    if file_size > PROFILE_IMAGE_MAX_SIZE_BYTES:
+        raise CustomAPIException(ErrorMessages.FILE_TOO_LARGE)
+
+    object_key = f"{PROFILE_IMAGE_UPLOAD_DIR}/{user.id}/{uuid.uuid4().hex}.{extension}"
+    upload_url = _get_s3_client().generate_presigned_url(
+        ClientMethod="put_object",
+        Params={
+            "Bucket": settings.AWS_STORAGE_BUCKET_NAME,
+            "Key": object_key,
+            "ContentType": content_type,
+        },
+        ExpiresIn=settings.AWS_S3_PRESIGNED_URL_EXPIRES_IN,
+    )
+    profile_img_url = _build_profile_image_url(object_key)
+
+    user.profile_img_url = profile_img_url
+    user.save(update_fields=["profile_img_url", "updated_at"])
+
+    return {
+        "upload_url": upload_url,
+        "profile_img_url": profile_img_url,
+        "expires_in": settings.AWS_S3_PRESIGNED_URL_EXPIRES_IN,
+    }
+
+
+def delete_user_profile_image(user: User) -> dict[str, object]:
+    user = get_user_me(user)
+    _ensure_profile_image_storage_config()
+
+    object_key = _get_profile_image_object_key(user.profile_img_url)
+    if object_key is not None:
+        _get_s3_client().delete_object(
+            Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+            Key=object_key,
+        )
+
+    user.profile_img_url = None
+    user.save(update_fields=["profile_img_url", "updated_at"])
+
+    return {"profile_img_url": None}

--- a/apps/users/tests/test_profile_image.py
+++ b/apps/users/tests/test_profile_image.py
@@ -47,7 +47,7 @@ class UserProfileImageAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["upload_url"], "https://signed.example.com/upload")
         self.assertEqual(response.json()["expires_in"], 3600)
-        self.assertTrue(response.json()["profile_img_url"].startswith("https://cdn.example.com/profile-images/"))
+        self.assertTrue(response.json()["profile_img_url"].startswith("https://cdn.example.com/images/profile/"))
 
         self.user.refresh_from_db()
         self.assertEqual(self.user.profile_img_url, response.json()["profile_img_url"])
@@ -123,7 +123,7 @@ class UserProfileImageAPITest(TestCase):
 
     def test_delete_profile_image_clears_profile_url(self) -> None:
         self.client.force_authenticate(user=self.user)
-        self.user.profile_img_url = f"https://cdn.example.com/profile-images/{self.user.id}/existing.png"
+        self.user.profile_img_url = f"https://cdn.example.com/images/profile/{self.user.id}/existing.png"
         self.user.save(update_fields=["profile_img_url"])
         mock_s3_client = MagicMock()
 
@@ -137,7 +137,7 @@ class UserProfileImageAPITest(TestCase):
         self.assertIsNone(self.user.profile_img_url)
         mock_s3_client.delete_object.assert_called_once_with(
             Bucket="test-bucket",
-            Key=f"profile-images/{self.user.id}/existing.png",
+            Key=f"images/profile/{self.user.id}/existing.png",
         )
 
     def test_delete_profile_image_without_existing_image_returns_none(self) -> None:

--- a/apps/users/tests/test_profile_image.py
+++ b/apps/users/tests/test_profile_image.py
@@ -1,0 +1,152 @@
+import datetime
+from unittest.mock import MagicMock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from apps.core.exceptions.exception_message import ErrorMessages
+
+
+@override_settings(
+    AWS_S3_REGION_NAME="ap-northeast-2",
+    AWS_STORAGE_BUCKET_NAME="test-bucket",
+    AWS_S3_PUBLIC_BASE_URL="https://cdn.example.com",
+    AWS_S3_PRESIGNED_URL_EXPIRES_IN=3600,
+)
+class UserProfileImageAPITest(TestCase):
+    def setUp(self) -> None:
+        self.client: APIClient = APIClient()
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            email="profile@example.com",
+            password="Passw0rd!",
+            nickname="profileuser",
+            birth_date=datetime.date(1999, 1, 1),
+        )
+        self.url = reverse("users-me-profile-image")
+
+    def test_create_profile_image_upload_url_returns_presigned_url(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        mock_s3_client = MagicMock()
+        mock_s3_client.generate_presigned_url.return_value = "https://signed.example.com/upload"
+
+        with override_settings(S3_CLIENT=mock_s3_client):
+            response = self.client.put(
+                self.url,
+                {
+                    "file_name": "avatar.png",
+                    "content_type": "image/png",
+                    "file_size": 1024,
+                },
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["upload_url"], "https://signed.example.com/upload")
+        self.assertEqual(response.json()["expires_in"], 3600)
+        self.assertTrue(response.json()["profile_img_url"].startswith("https://cdn.example.com/profile-images/"))
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.profile_img_url, response.json()["profile_img_url"])
+        mock_s3_client.generate_presigned_url.assert_called_once()
+        _, kwargs = mock_s3_client.generate_presigned_url.call_args
+        self.assertEqual(kwargs["ClientMethod"], "put_object")
+        self.assertEqual(kwargs["Params"]["Bucket"], "test-bucket")
+        self.assertEqual(kwargs["Params"]["ContentType"], "image/png")
+        self.assertEqual(kwargs["ExpiresIn"], 3600)
+
+    def test_create_profile_image_upload_url_returns_401_when_not_authenticated(self) -> None:
+        response = self.client.put(
+            self.url,
+            {
+                "file_name": "avatar.png",
+                "content_type": "image/png",
+                "file_size": 1024,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_create_profile_image_upload_url_returns_400_for_invalid_extension(self) -> None:
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.put(
+            self.url,
+            {
+                "file_name": "avatar.txt",
+                "content_type": "text/plain",
+                "file_size": 1024,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["code"], ErrorMessages.INVALID_FILE_TYPE.name)
+
+    def test_create_profile_image_upload_url_returns_400_for_large_file(self) -> None:
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.put(
+            self.url,
+            {
+                "file_name": "avatar.png",
+                "content_type": "image/png",
+                "file_size": 5 * 1024 * 1024 + 1,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["code"], ErrorMessages.FILE_TOO_LARGE.name)
+
+    def test_create_profile_image_upload_url_returns_404_when_user_is_deleted(self) -> None:
+        self.user.deleted_at = timezone.now()
+        self.user.save(update_fields=["deleted_at"])
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.put(
+            self.url,
+            {
+                "file_name": "avatar.png",
+                "content_type": "image/png",
+                "file_size": 1024,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["code"], ErrorMessages.USER_NOT_FOUND.name)
+
+    def test_delete_profile_image_clears_profile_url(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        self.user.profile_img_url = f"https://cdn.example.com/profile-images/{self.user.id}/existing.png"
+        self.user.save(update_fields=["profile_img_url"])
+        mock_s3_client = MagicMock()
+
+        with override_settings(S3_CLIENT=mock_s3_client):
+            response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()["profile_img_url"])
+
+        self.user.refresh_from_db()
+        self.assertIsNone(self.user.profile_img_url)
+        mock_s3_client.delete_object.assert_called_once_with(
+            Bucket="test-bucket",
+            Key=f"profile-images/{self.user.id}/existing.png",
+        )
+
+    def test_delete_profile_image_without_existing_image_returns_none(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        mock_s3_client = MagicMock()
+
+        with override_settings(S3_CLIENT=mock_s3_client):
+            response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()["profile_img_url"])
+        mock_s3_client.delete_object.assert_not_called()

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -15,11 +15,13 @@ from apps.users.views.auth import (
     RefreshAPIView,
     SignupAPIView,
 )
-from apps.users.views.me import UserMeAPIView, UserPasswordChangeAPIView, UserPasswordVerifyAPIView
-from apps.users.views.search_recent import (
-    RecentSearchAPIView,
-    RecentSearchKeywordDeleteAPIView,
+from apps.users.views.me import (
+    UserMeAPIView,
+    UserPasswordChangeAPIView,
+    UserPasswordVerifyAPIView,
+    UserProfileImageAPIView,
 )
+from apps.users.views.search_recent import RecentSearchAPIView, RecentSearchKeywordDeleteAPIView
 from apps.users.views.social_auth import (
     DiscordCallbackAPIView,
     DiscordLoginAPIView,
@@ -45,6 +47,7 @@ urlpatterns = [
     path("users/me/", UserMeAPIView.as_view(), name="users-me"),
     path("users/me/verify-password/", UserPasswordVerifyAPIView.as_view(), name="users-me-verify-password"),
     path("users/me/password/", UserPasswordChangeAPIView.as_view(), name="users-me-password-change"),
+    path("users/me/profile-image/", UserProfileImageAPIView.as_view(), name="users-me-profile-image"),
     path("auth/kakao/login/", KakaoLoginAPIView.as_view(), name="auth-kakao-login"),
     path("auth/kakao/callback/", KakaoCallbackAPIView.as_view(), name="auth-kakao-callback"),
     path("auth/discord/login/", DiscordLoginAPIView.as_view(), name="auth-discord-login"),

--- a/apps/users/views/me.py
+++ b/apps/users/views/me.py
@@ -16,10 +16,15 @@ from apps.users.serializers.me import (
     UserMeUpdateResponseSerializer,
     UserPasswordChangeRequestSerializer,
     UserPasswordVerifyRequestSerializer,
+    UserProfileImageResponseSerializer,
+    UserProfileImageUploadRequestSerializer,
+    UserProfileImageUploadResponseSerializer,
 )
 from apps.users.services import (
     change_user_password,
+    create_user_profile_image_upload_url,
     delete_user_me,
+    delete_user_profile_image,
     get_user_me,
     update_user_me,
     verify_user_password,
@@ -112,3 +117,35 @@ class UserPasswordChangeAPIView(APIView):
             new_password=cast(str, serializer.validated_data["new_password"]),
         )
         return Response(MessageResponseSerializer({"message": "비밀번호가 변경되었습니다."}).data)
+
+
+@extend_schema(
+    summary="프로필 이미지 업로드 URL 발급",
+    request=UserProfileImageUploadRequestSerializer,
+    responses={200: UserProfileImageUploadResponseSerializer},
+    tags=["Users"],
+)
+class UserProfileImageAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def put(self, request: Request) -> Response:
+        serializer = UserProfileImageUploadRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        result = create_user_profile_image_upload_url(
+            cast(User, request.user),
+            file_name=cast(str, serializer.validated_data["file_name"]),
+            content_type=cast(str, serializer.validated_data["content_type"]),
+            file_size=cast(int, serializer.validated_data["file_size"]),
+        )
+        return Response(UserProfileImageUploadResponseSerializer(result).data)
+
+    @extend_schema(
+        summary="프로필 이미지 삭제",
+        request=None,
+        responses={200: UserProfileImageResponseSerializer},
+        tags=["Users"],
+    )
+    def delete(self, request: Request) -> Response:
+        result = delete_user_profile_image(cast(User, request.user))
+        return Response(UserProfileImageResponseSerializer(result).data)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -243,17 +243,9 @@ from celery.schedules import crontab  # noqa: E402
 ACCOUNT_DELETION_RETENTION_DAYS = int(os.getenv("ACCOUNT_DELETION_RETENTION_DAYS", "7"))
 
 CELERY_BEAT_SCHEDULE = {
-    "rawg-incremental-sync": {
-        "task": "apps.games.tasks.incremental_sync",
-        "schedule": crontab(hour=3, minute=0),
-    },
     "users-purge-soft-deleted": {
         "task": "apps.users.tasks.purge_soft_deleted_users",
         "schedule": crontab(hour=4, minute=0),
-    },
-    "igdb-incremental-sync": {
-        "task": "apps.games.igdb.tasks.incremental_sync",
-        "schedule": crontab(hour=2, minute=0),
     },
     "recommendation-process-pending-jobs": {
         "task": "apps.recommendations.tasks.process_pending_recommendation_jobs",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -23,6 +23,13 @@ DISCORD_AUTHORIZE_URL = "https://discord.com/oauth2/authorize"
 DISCORD_TOKEN_URL = "https://discord.com/api/v10/oauth2/token"
 DISCORD_USER_INFO_URL = "https://discord.com/api/v10/users/@me"
 FRONTEND_DOMAIN = os.getenv("FRONTEND_DOMAIN")
+FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL")
+SOCIAL_LOGIN_SUCCESS_URL = os.getenv("SOCIAL_LOGIN_SUCCESS_URL")
+SOCIAL_LOGIN_ONBOARDING_URL = os.getenv("SOCIAL_LOGIN_ONBOARDING_URL")
+AWS_S3_REGION_NAME = os.getenv("AWS_S3_REGION_NAME")
+AWS_STORAGE_BUCKET_NAME = os.getenv("AWS_STORAGE_BUCKET_NAME")
+AWS_S3_PUBLIC_BASE_URL = os.getenv("AWS_S3_PUBLIC_BASE_URL")
+AWS_S3_PRESIGNED_URL_EXPIRES_IN = int(os.getenv("AWS_S3_PRESIGNED_URL_EXPIRES_IN", "3600"))
 BBATON_AUTHORIZE_URL = os.getenv("BBATON_AUTHORIZE_URL")
 BBATON_TOKEN_URL = os.getenv("BBATON_TOKEN_URL")
 BBATON_USER_INFO_URL = os.getenv("BBATON_USER_INFO_URL")
@@ -236,9 +243,17 @@ from celery.schedules import crontab  # noqa: E402
 ACCOUNT_DELETION_RETENTION_DAYS = int(os.getenv("ACCOUNT_DELETION_RETENTION_DAYS", "7"))
 
 CELERY_BEAT_SCHEDULE = {
+    "rawg-incremental-sync": {
+        "task": "apps.games.tasks.incremental_sync",
+        "schedule": crontab(hour=3, minute=0),
+    },
     "users-purge-soft-deleted": {
         "task": "apps.users.tasks.purge_soft_deleted_users",
         "schedule": crontab(hour=4, minute=0),
+    },
+    "igdb-incremental-sync": {
+        "task": "apps.games.igdb.tasks.incremental_sync",
+        "schedule": crontab(hour=2, minute=0),
     },
     "recommendation-process-pending-jobs": {
         "task": "apps.recommendations.tasks.process_pending_recommendation_jobs",


### PR DESCRIPTION
## ✅ PR 요약
- 프로필 이미지 업로드를 위해 S3 presigned URL 발급 및 삭제 API를 추가했습니다.

## 📄 상세 내용
- [x] `PUT /api/v1/users/me/profile-image/` 엔드포인트를 추가해 프로필 이미지 업로드용 presigned URL을 발급하도록 구현했습니다.
- [x] 파일명, MIME 타입, 파일 크기를 검증하고 허용된 이미지 형식(`jpg`, `jpeg`, `png`, `webp`)만 업로드할 수 있도록 처리했습니다.
- [x] 최대 파일 크기 5MB 제한을 적용했습니다.
- [x] 업로드 경로를 `images/profile/{user_id}/{uuid}.{ext}` 형식으로 생성하도록 반영했습니다.
- [x] presigned URL 발급 시 사용자 `profile_img_url`을 함께 갱신하도록 처리했습니다.
- [x] `DELETE /api/v1/users/me/profile-image/` 엔드포인트를 추가해 기존 프로필 이미지 URL을 제거하고, 저장소 객체도 함께 삭제하도록 구현했습니다.
- [x] 프로필 이미지 발급/삭제 및 예외 케이스 테스트를 추가했습니다.

