### PR TITLE
[Feature/admin/dashboard-summary] 관리자 대시보드 요약 조회 API 추가

### DIFF
--- a/apps/users/serializers/admin_user.py
+++ b/apps/users/serializers/admin_user.py
@@ -51,3 +51,10 @@ class AdminUserDetailResponseSerializer(serializers.ModelSerializer[User]):
 
 class AdminUserStatusUpdateRequestSerializer(serializers.Serializer[dict[str, object]]):
     is_active = serializers.BooleanField()
+
+
+class AdminDashboardSummaryResponseSerializer(serializers.Serializer[dict[str, object]]):
+    total_users = serializers.IntegerField()
+    active_users = serializers.IntegerField()
+    recommendation_jobs_today = serializers.IntegerField()
+    failed_jobs = serializers.IntegerField()

--- a/apps/users/services/__init__.py
+++ b/apps/users/services/__init__.py
@@ -1,4 +1,4 @@
-from .admin_user_service import get_admin_user, list_admin_users, update_admin_user_status
+from .admin_user_service import get_admin_dashboard_summary, get_admin_user, list_admin_users, update_admin_user_status
 from .auth_service import (
     authenticate_user,
     get_active_user_or_deactivated,
@@ -30,6 +30,7 @@ __all__ = [
     "clear_recent_searches",
     "delete_recent_search_keyword",
     "delete_user_me",
+    "get_admin_dashboard_summary",
     "get_admin_user",
     "get_active_user_or_deactivated",
     "get_recent_searches",

--- a/apps/users/services/admin_user_service.py
+++ b/apps/users/services/admin_user_service.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from django.db.models import QuerySet
+from django.utils import timezone
 
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
+from apps.recommendations.models import RecommendationJob
 from apps.users.models.user import User
 
 
@@ -23,3 +25,15 @@ def update_admin_user_status(*, user_id: int, is_active: bool) -> User:
     user.is_active = is_active
     user.save(update_fields=["is_active", "updated_at"])
     return user
+
+
+def get_admin_dashboard_summary() -> dict[str, int]:
+    today = timezone.localdate()
+    visible_users = User.objects.filter(deleted_at__isnull=True)
+
+    return {
+        "total_users": visible_users.count(),
+        "active_users": visible_users.filter(is_active=True).count(),
+        "recommendation_jobs_today": RecommendationJob.objects.filter(created_at__date=today).count(),
+        "failed_jobs": RecommendationJob.objects.filter(status=RecommendationJob.Status.FAILED).count(),
+    }

--- a/apps/users/services/admin_user_service.py
+++ b/apps/users/services/admin_user_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.db.models import QuerySet
+from django.db.models import Count, Q, QuerySet
 from django.utils import timezone
 
 from apps.core.exceptions.exception_handler import CustomAPIException
@@ -29,11 +29,18 @@ def update_admin_user_status(*, user_id: int, is_active: bool) -> User:
 
 def get_admin_dashboard_summary() -> dict[str, int]:
     today = timezone.localdate()
-    visible_users = User.objects.filter(deleted_at__isnull=True)
+    user_summary = User.objects.filter(deleted_at__isnull=True).aggregate(
+        total_users=Count("id"),
+        active_users=Count("id", filter=Q(is_active=True)),
+    )
+    job_summary = RecommendationJob.objects.aggregate(
+        recommendation_jobs_today=Count("id", filter=Q(created_at__date=today)),
+        failed_jobs=Count("id", filter=Q(status=RecommendationJob.Status.FAILED)),
+    )
 
     return {
-        "total_users": visible_users.count(),
-        "active_users": visible_users.filter(is_active=True).count(),
-        "recommendation_jobs_today": RecommendationJob.objects.filter(created_at__date=today).count(),
-        "failed_jobs": RecommendationJob.objects.filter(status=RecommendationJob.Status.FAILED).count(),
+        "total_users": int(user_summary["total_users"]),
+        "active_users": int(user_summary["active_users"]),
+        "recommendation_jobs_today": int(job_summary["recommendation_jobs_today"]),
+        "failed_jobs": int(job_summary["failed_jobs"]),
     }

--- a/apps/users/tests/test_admin_users.py
+++ b/apps/users/tests/test_admin_users.py
@@ -3,9 +3,11 @@ import datetime
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework.test import APIClient
 
 from apps.core.exceptions.exception_message import ErrorMessages
+from apps.recommendations.models import RecommendationJob
 
 User = get_user_model()
 
@@ -33,6 +35,43 @@ class AdminUserAPITestCase(TestCase):
         )
         self.list_url = reverse("admin-user-list")
         self.detail_url = reverse("admin-user-detail", args=[self.user.id])
+        self.dashboard_url = reverse("admin-dashboard-summary")
+
+    def test_admin_dashboard_summary_returns_counts_for_admin(self) -> None:
+        self.client.force_authenticate(user=self.admin_user)
+
+        failed_job = RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.USER_REFRESH,
+            target_user=self.user,
+            status=RecommendationJob.Status.FAILED,
+        )
+        RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.SIMILARITY_REBUILD,
+            status=RecommendationJob.Status.PENDING,
+        )
+        yesterday = timezone.now() - datetime.timedelta(days=1)
+        RecommendationJob.objects.filter(id=failed_job.id).update(created_at=yesterday)
+
+        response = self.client.get(self.dashboard_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["total_users"], 3)
+        self.assertEqual(response.json()["active_users"], 3)
+        self.assertEqual(response.json()["recommendation_jobs_today"], 1)
+        self.assertEqual(response.json()["failed_jobs"], 1)
+
+    def test_admin_dashboard_summary_returns_403_for_non_admin(self) -> None:
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(self.dashboard_url)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["code"], ErrorMessages.FORBIDDEN.name)
+
+    def test_admin_dashboard_summary_returns_401_when_not_authenticated(self) -> None:
+        response = self.client.get(self.dashboard_url)
+
+        self.assertEqual(response.status_code, 401)
 
     def test_admin_user_list_returns_paginated_users_for_admin(self) -> None:
         self.client.force_authenticate(user=self.admin_user)

--- a/apps/users/urls_admin.py
+++ b/apps/users/urls_admin.py
@@ -1,11 +1,13 @@
 from django.urls import path
 
 from apps.users.views_admin import (
+    AdminDashboardSummaryAPIView,
     AdminUserDetailAPIView,
     AdminUserListAPIView,
 )
 
 urlpatterns = [
+    path("dashboard/", AdminDashboardSummaryAPIView.as_view(), name="admin-dashboard-summary"),
     path("", AdminUserListAPIView.as_view(), name="admin-user-list"),
     path("<int:user_id>/", AdminUserDetailAPIView.as_view(), name="admin-user-detail"),
 ]

--- a/apps/users/views_admin.py
+++ b/apps/users/views_admin.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 from django.db.models import QuerySet
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
@@ -14,12 +16,30 @@ from apps.core.serializers.error_serializer import ErrorResponseSerializer
 from apps.core.utils.pagination import PAGINATION_PARAMS, Pagination
 from apps.users.models.user import User
 from apps.users.serializers.admin_user import (
+    AdminDashboardSummaryResponseSerializer,
     AdminUserDetailResponseSerializer,
     AdminUserListItemSerializer,
     AdminUserListResponseSerializer,
     AdminUserStatusUpdateRequestSerializer,
 )
-from apps.users.services import get_admin_user, list_admin_users, update_admin_user_status
+from apps.users.services import get_admin_dashboard_summary, get_admin_user, list_admin_users, update_admin_user_status
+
+
+@extend_schema(
+    tags=["admin"],
+    summary="어드민 - 대시보드 요약 조회",
+    responses={
+        200: AdminDashboardSummaryResponseSerializer,
+        401: ErrorResponseSerializer,
+        403: ErrorResponseSerializer,
+    },
+)
+class AdminDashboardSummaryAPIView(APIView):
+    permission_classes = [IsAuthenticated, IsStaffAdmin]
+
+    def get(self, request: Request) -> Response:
+        serializer = AdminDashboardSummaryResponseSerializer(cast(dict[str, object], get_admin_dashboard_summary()))
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 @extend_schema(


### PR DESCRIPTION
## ✅ PR 요약
- 관리자 대시보드에서 운영 현황을 확인할 수 있도록 요약 조회 API를 추가했습니다.

## 📄 상세 내용
- [x] `GET /api/v1/admin/users/dashboard/` 엔드포인트를 추가했습니다.
- [x] 관리자 권한(`is_staff`)이 있는 사용자만 접근할 수 있도록 권한 검사를 적용했습니다.
- [x] 대시보드 응답에 아래 4개 지표를 포함하도록 구현했습니다.
- [x] `total_users`: 탈퇴되지 않은 전체 유저 수
- [x] `active_users`: 탈퇴되지 않았고 활성 상태인 유저 수
- [x] `recommendation_jobs_today`: 오늘 생성된 추천 작업 수
- [x] `failed_jobs`: 실패 상태 추천 작업 수
- [x] 기존 `users` admin 도메인 구조에 맞춰 serializer/service/view/test를 분리해 추가했습니다.
- [x] 관리자, 비관리자, 비로그인 케이스에 대한 테스트를 작성했습니다.

