### PR TITLE
[Feature/users/adult-verification-redirect] 성인인증 콜백 프론트 리다이렉트 처리 추가

### DIFF
--- a/apps/users/tests/test_adult_verification.py
+++ b/apps/users/tests/test_adult_verification.py
@@ -44,6 +44,15 @@ class AdultVerificationAPITestCase(TestCase):
         self.callback_url = "/api/v1/users/me/adult-verifications/callback/"
         self.status_url = "/api/v1/users/me/adult-verifications/"
 
+    def _assert_redirects_to_frontend_callback(self, response: HttpResponseRedirect) -> dict[str, list[str]]:
+        self.assertEqual(response.status_code, 302)
+        parsed_url = urlparse(response["Location"])
+        self.assertEqual(
+            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}",
+            "https://frontend.example.com/auth/callback",
+        )
+        return parse_qs(parsed_url.query)
+
     def test_initiate_redirects_to_bbaton_and_saves_state(self) -> None:
         self.client.force_authenticate(user=self.user)
 
@@ -73,12 +82,7 @@ class AdultVerificationAPITestCase(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 302)
-        parsed_url = urlparse(response["Location"])
-        query = parse_qs(parsed_url.query)
-        self.assertEqual(
-            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", "https://frontend.example.com/auth/callback"
-        )
+        query = self._assert_redirects_to_frontend_callback(cast(HttpResponseRedirect, response))
         self.assertEqual(query["error"][0], ErrorMessages.INVALID_STATE.name)
 
     @patch("apps.users.services.adult_verification_service._request_bbaton_user_info")
@@ -104,12 +108,7 @@ class AdultVerificationAPITestCase(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 302)
-        parsed_url = urlparse(response["Location"])
-        query = parse_qs(parsed_url.query)
-        self.assertEqual(
-            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", "https://frontend.example.com/auth/callback"
-        )
+        query = self._assert_redirects_to_frontend_callback(cast(HttpResponseRedirect, response))
         self.assertEqual(query["is_adult_verified"][0], "true")
         self.assertTrue(query["adult_verified_at"][0])
         self.assertTrue(query["expires_at"][0])
@@ -150,12 +149,7 @@ class AdultVerificationAPITestCase(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 302)
-        parsed_url = urlparse(response["Location"])
-        query = parse_qs(parsed_url.query)
-        self.assertEqual(
-            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", "https://frontend.example.com/auth/callback"
-        )
+        query = self._assert_redirects_to_frontend_callback(cast(HttpResponseRedirect, response))
         self.assertEqual(query["error"][0], ErrorMessages.UNDERAGE.name)
 
     def test_callback_returns_already_verified_for_valid_user(self) -> None:
@@ -175,12 +169,7 @@ class AdultVerificationAPITestCase(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 302)
-        parsed_url = urlparse(response["Location"])
-        query = parse_qs(parsed_url.query)
-        self.assertEqual(
-            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", "https://frontend.example.com/auth/callback"
-        )
+        query = self._assert_redirects_to_frontend_callback(cast(HttpResponseRedirect, response))
         self.assertEqual(query["error"][0], ErrorMessages.ALREADY_VERIFIED.name)
 
     @patch("apps.users.services.adult_verification_service._request_bbaton_user_info")
@@ -220,12 +209,7 @@ class AdultVerificationAPITestCase(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 302)
-        parsed_url = urlparse(response["Location"])
-        query = parse_qs(parsed_url.query)
-        self.assertEqual(
-            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", "https://frontend.example.com/auth/callback"
-        )
+        query = self._assert_redirects_to_frontend_callback(cast(HttpResponseRedirect, response))
         self.assertEqual(query["error"][0], ErrorMessages.VERIFICATION_ALREADY_USED.name)
 
     def test_status_returns_current_adult_verification_state(self) -> None:

--- a/apps/users/tests/test_adult_verification.py
+++ b/apps/users/tests/test_adult_verification.py
@@ -28,6 +28,7 @@ from apps.users.services.adult_verification_service import (
     BBATON_CLIENT_ID="test-client-id",
     BBATON_CLIENT_SECRET="test-client-secret",
     BBATON_REDIRECT_URI="https://example.com/api/v1/users/me/adult-verifications/callback/",
+    FRONTEND_BASE_URL="https://frontend.example.com",
 )
 class AdultVerificationAPITestCase(TestCase):
     def setUp(self) -> None:
@@ -72,8 +73,13 @@ class AdultVerificationAPITestCase(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()["code"], ErrorMessages.INVALID_STATE.name)
+        self.assertEqual(response.status_code, 302)
+        parsed_url = urlparse(response["Location"])
+        query = parse_qs(parsed_url.query)
+        self.assertEqual(
+            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", "https://frontend.example.com/auth/callback"
+        )
+        self.assertEqual(query["error"][0], ErrorMessages.INVALID_STATE.name)
 
     @patch("apps.users.services.adult_verification_service._request_bbaton_user_info")
     @patch("apps.users.services.adult_verification_service._request_bbaton_access_token")
@@ -98,10 +104,15 @@ class AdultVerificationAPITestCase(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.json()["is_adult_verified"])
-        self.assertIsNotNone(response.json()["adult_verified_at"])
-        self.assertIsNotNone(response.json()["expires_at"])
+        self.assertEqual(response.status_code, 302)
+        parsed_url = urlparse(response["Location"])
+        query = parse_qs(parsed_url.query)
+        self.assertEqual(
+            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", "https://frontend.example.com/auth/callback"
+        )
+        self.assertEqual(query["is_adult_verified"][0], "true")
+        self.assertTrue(query["adult_verified_at"][0])
+        self.assertTrue(query["expires_at"][0])
 
         self.user.refresh_from_db()
         self.assertTrue(self.user.is_adult_verified)
@@ -139,8 +150,13 @@ class AdultVerificationAPITestCase(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()["code"], ErrorMessages.UNDERAGE.name)
+        self.assertEqual(response.status_code, 302)
+        parsed_url = urlparse(response["Location"])
+        query = parse_qs(parsed_url.query)
+        self.assertEqual(
+            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", "https://frontend.example.com/auth/callback"
+        )
+        self.assertEqual(query["error"][0], ErrorMessages.UNDERAGE.name)
 
     def test_callback_returns_already_verified_for_valid_user(self) -> None:
         self.user.is_adult_verified = True
@@ -159,8 +175,13 @@ class AdultVerificationAPITestCase(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()["code"], ErrorMessages.ALREADY_VERIFIED.name)
+        self.assertEqual(response.status_code, 302)
+        parsed_url = urlparse(response["Location"])
+        query = parse_qs(parsed_url.query)
+        self.assertEqual(
+            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", "https://frontend.example.com/auth/callback"
+        )
+        self.assertEqual(query["error"][0], ErrorMessages.ALREADY_VERIFIED.name)
 
     @patch("apps.users.services.adult_verification_service._request_bbaton_user_info")
     @patch("apps.users.services.adult_verification_service._request_bbaton_access_token")
@@ -199,8 +220,13 @@ class AdultVerificationAPITestCase(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 409)
-        self.assertEqual(response.json()["code"], ErrorMessages.VERIFICATION_ALREADY_USED.name)
+        self.assertEqual(response.status_code, 302)
+        parsed_url = urlparse(response["Location"])
+        query = parse_qs(parsed_url.query)
+        self.assertEqual(
+            f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}", "https://frontend.example.com/auth/callback"
+        )
+        self.assertEqual(query["error"][0], ErrorMessages.VERIFICATION_ALREADY_USED.name)
 
     def test_status_returns_current_adult_verification_state(self) -> None:
         verified_at = timezone.now()

--- a/apps/users/views/adult_verification.py
+++ b/apps/users/views/adult_verification.py
@@ -98,12 +98,10 @@ class AdultVerificationCallbackAPIView(APIView):
     def get(self, request: Request) -> Response | HttpResponseRedirect:
         serializer = AdultVerificationCallbackRequestSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
-        code = cast(str, serializer.validated_data["code"])
-        state = cast(str, serializer.validated_data["state"])
         redirect_url = _resolve_adult_verification_redirect_url(request)
 
         try:
-            result = complete_adult_verification(code=code, state=state)
+            result = complete_adult_verification(**serializer.validated_data)
         except CustomAPIException as error:
             error_detail = cast(dict[str, object], error.detail)
             return redirect(

--- a/apps/users/views/adult_verification.py
+++ b/apps/users/views/adult_verification.py
@@ -1,19 +1,21 @@
+from datetime import datetime
 from typing import cast
+from urllib.parse import parse_qsl, urlencode, urljoin, urlsplit, urlunsplit
 
+from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
-from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.serializers.error_serializer import ErrorResponseSerializer
 from apps.users.models.user import User
 from apps.users.serializers.adult_verification import (
     AdultVerificationCallbackRequestSerializer,
-    AdultVerificationCallbackResponseSerializer,
     AdultVerificationStatusResponseSerializer,
 )
 from apps.users.services.adult_verification_service import (
@@ -23,8 +25,26 @@ from apps.users.services.adult_verification_service import (
 )
 
 
+def _append_query_params(url: str, **params: str) -> str:
+    split_result = urlsplit(url)
+    query_params = dict(parse_qsl(split_result.query, keep_blank_values=True))
+    query_params.update(params)
+    return urlunsplit(split_result._replace(query=urlencode(query_params)))
+
+
+def _resolve_adult_verification_redirect_url(request: Request) -> str:
+    frontend_base_url = getattr(settings, "FRONTEND_BASE_URL", None) or getattr(settings, "FRONTEND_DOMAIN", None)
+    if isinstance(frontend_base_url, str) and frontend_base_url:
+        return urljoin(frontend_base_url.rstrip("/") + "/", "auth/callback")
+    return request.build_absolute_uri("/")
+
+
+def _isoformat(value: object) -> str:
+    return cast(datetime, value).isoformat()
+
+
 @extend_schema(
-    summary="비바톤 성인인증 리다이렉트",
+    summary="Adult Verification Initiate",
     request=None,
     responses={
         302: OpenApiResponse(description="Redirect to Bbaton OAuth"),
@@ -41,7 +61,7 @@ class AdultVerificationInitiateAPIView(APIView):
 
 
 @extend_schema(
-    summary="성인 인증 비바톤 콜백",
+    summary="Adult Verification Callback",
     request=None,
     parameters=[
         OpenApiParameter(
@@ -49,21 +69,21 @@ class AdultVerificationInitiateAPIView(APIView):
             type=str,
             location=OpenApiParameter.QUERY,
             required=True,
-            description="비바톤 OAuth 인증 코드",
+            description="Bbaton OAuth authorization code",
         ),
         OpenApiParameter(
             name="state",
             type=str,
             location=OpenApiParameter.QUERY,
             required=True,
-            description="비바톤 OAuth state 값",
+            description="Bbaton OAuth state value",
         ),
     ],
     responses={
-        200: AdultVerificationCallbackResponseSerializer,
+        302: OpenApiResponse(description="Redirect to frontend after adult verification"),
         400: OpenApiResponse(
             response=ErrorResponseSerializer,
-            description="INVALID_STATE, OAUTH_CALLBACK_ERROR, UNDERAGE, ALREADY_VERIFIED",
+            description="INVALID_STATE, ADULT_VERIFICATION_CALLBACK_ERROR, UNDERAGE, ALREADY_VERIFIED",
         ),
         409: OpenApiResponse(
             response=ErrorResponseSerializer,
@@ -75,19 +95,37 @@ class AdultVerificationInitiateAPIView(APIView):
 class AdultVerificationCallbackAPIView(APIView):
     permission_classes = [AllowAny]
 
-    def get(self, request: Request) -> Response:
+    def get(self, request: Request) -> Response | HttpResponseRedirect:
         serializer = AdultVerificationCallbackRequestSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
+        code = cast(str, serializer.validated_data["code"])
+        state = cast(str, serializer.validated_data["state"])
+        redirect_url = _resolve_adult_verification_redirect_url(request)
 
-        result = complete_adult_verification(**serializer.validated_data)
-        return Response(
-            AdultVerificationCallbackResponseSerializer(result).data,
-            status=status.HTTP_200_OK,
+        try:
+            result = complete_adult_verification(code=code, state=state)
+        except CustomAPIException as error:
+            error_detail = cast(dict[str, object], error.detail)
+            return redirect(
+                _append_query_params(
+                    redirect_url,
+                    error=cast(str, error_detail["code"]),
+                    error_description=cast(str, error_detail["message"]),
+                )
+            )
+
+        return redirect(
+            _append_query_params(
+                redirect_url,
+                is_adult_verified=str(cast(bool, result["is_adult_verified"])).lower(),
+                adult_verified_at=_isoformat(result["adult_verified_at"]),
+                expires_at=_isoformat(result["expires_at"]),
+            )
         )
 
 
 @extend_schema(
-    summary="성인 인증 상태 조회",
+    summary="Adult Verification Status",
     request=None,
     responses={
         200: AdultVerificationStatusResponseSerializer,
@@ -102,5 +140,4 @@ class AdultVerificationStatusAPIView(APIView):
         result = get_adult_verification_status(user=cast(User, request.user))
         return Response(
             AdultVerificationStatusResponseSerializer(result).data,
-            status=status.HTTP_200_OK,
         )


### PR DESCRIPTION
## ✅ PR 요약
- 비바톤 성인인증 완료 후 callback 응답을 JSON 대신 프론트 페이지로 리다이렉트하도록 수정했습니다.

## 📄 상세 내용
- [x] `GET /api/v1/users/me/adult-verifications/initiate/`는 기존처럼 비바톤 인증 페이지로 리다이렉트하도록 유지했습니다.
- [x] `GET /api/v1/users/me/adult-verifications/callback/` 성공 시 프론트 `auth/callback` 경로로 리다이렉트되도록 변경했습니다.
- [x] 성공 시 `is_adult_verified`, `adult_verified_at`, `expires_at`를 query parameter로 전달하도록 처리했습니다.
- [x] 실패 시 `error`, `error_description`를 query parameter로 전달하도록 처리했습니다.
- [x] 성인인증 상태 저장 로직은 기존과 동일하게 유지했습니다.
- [x] 관련 테스트를 JSON 응답 기준에서 프론트 리다이렉트 기준으로 수정했습니다.

