### PR TITLE
[Feature/auth/email-code-branching] 이메일 인증코드 발송 목적별 분기 처리 및 Swagger 정리

### DIFF
--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -52,6 +52,9 @@ def get_active_user_or_deactivated(user: User) -> User:
 
 
 def send_email_code(*, email: str, purpose: str) -> int:
+    if purpose == EMAIL_CODE_PURPOSE_SIGNUP and User.objects.filter(email=email).exists():
+        raise CustomAPIException(ErrorMessages.EMAIL_ALREADY_EXISTS)
+
     cooldown_key = _email_code_cooldown_key(purpose=purpose, email=email)
     if cache.get(cooldown_key):
         raise CustomAPIException(ErrorMessages.TOO_MANY_REQUESTS)

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -38,8 +38,7 @@ def _email_code_attempts_key(*, purpose: str, email: str) -> str:
     return f"email_code_attempts:{purpose}:{email}"
 
 
-def _should_issue_email_code(*, email: str, purpose: str) -> bool:
-    user_exists = User.objects.filter(email=email).exists()
+def _should_issue_email_code(*, purpose: str, user_exists: bool) -> bool:
     if purpose == EMAIL_CODE_PURPOSE_SIGNUP:
         return not user_exists
     return user_exists
@@ -52,7 +51,8 @@ def get_active_user_or_deactivated(user: User) -> User:
 
 
 def send_email_code(*, email: str, purpose: str) -> int:
-    if purpose == EMAIL_CODE_PURPOSE_SIGNUP and User.objects.filter(email=email).exists():
+    user_exists = User.objects.filter(email=email).exists()
+    if purpose == EMAIL_CODE_PURPOSE_SIGNUP and user_exists:
         raise CustomAPIException(ErrorMessages.EMAIL_ALREADY_EXISTS)
 
     cooldown_key = _email_code_cooldown_key(purpose=purpose, email=email)
@@ -61,7 +61,7 @@ def send_email_code(*, email: str, purpose: str) -> int:
 
     cache.set(cooldown_key, True, timeout=EMAIL_CODE_COOLDOWN_SECONDS)
 
-    if _should_issue_email_code(email=email, purpose=purpose):
+    if _should_issue_email_code(purpose=purpose, user_exists=user_exists):
         code = f"{secrets.randbelow(1000000):06d}"
         cache.set(_email_code_key(purpose=purpose, email=email), code, timeout=EMAIL_CODE_TTL_SECONDS)
         cache.delete(_email_code_attempts_key(purpose=purpose, email=email))

--- a/apps/users/tests/test_email_code_send.py
+++ b/apps/users/tests/test_email_code_send.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
+from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
 
 
@@ -16,6 +17,11 @@ class EmailCodeSendAPITest(TestCase):
         self.email = "user@example.com"
         cache.delete(f"email_code:signup:{self.email}")
         cache.delete(f"email_code_cooldown:signup:{self.email}")
+        cache.delete(f"email_code:password_reset:{self.email}")
+        cache.delete(f"email_code_cooldown:password_reset:{self.email}")
+        cache.delete(f"email_code_attempts:password_reset:{self.email}")
+        cache.delete("email_code:password_reset:missing@example.com")
+        cache.delete("email_code_cooldown:password_reset:missing@example.com")
 
     @patch("apps.users.services.auth_service.send_mail")
     def test_send_email_code_stores_code_in_cache(self, mock_send_mail: MagicMock) -> None:
@@ -73,3 +79,41 @@ class EmailCodeSendAPITest(TestCase):
         self.assertEqual(drf_res.data.get("expires_in"), 300)
         self.assertIsNone(cache.get("email_code:password_reset:missing@example.com"))
         mock_send_mail.assert_not_called()
+
+    @patch("apps.users.services.auth_service.send_mail")
+    def test_send_signup_code_returns_conflict_for_existing_email(self, mock_send_mail: MagicMock) -> None:
+        User.objects.create_user(
+            email=self.email,
+            nickname="tester",
+            birth_date=datetime.date(1997, 10, 2),
+            password="OldPass1234!",
+        )
+
+        res = self.client.post(
+            "/api/v1/auth/email/code/",
+            data={"email": self.email, "purpose": "signup"},
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, 409)
+        self.assertEqual(res.json()["code"], ErrorMessages.EMAIL_ALREADY_EXISTS.name)
+        self.assertIsNone(cache.get(f"email_code:signup:{self.email}"))
+        mock_send_mail.assert_not_called()
+
+    @patch("apps.users.services.auth_service.send_mail")
+    def test_send_signup_code_returns_too_many_requests_during_cooldown(self, mock_send_mail: MagicMock) -> None:
+        first_response = self.client.post(
+            "/api/v1/auth/email/code/",
+            data={"email": self.email, "purpose": "signup"},
+            format="json",
+        )
+        second_response = self.client.post(
+            "/api/v1/auth/email/code/",
+            data={"email": self.email, "purpose": "signup"},
+            format="json",
+        )
+
+        self.assertEqual(first_response.status_code, 201)
+        self.assertEqual(second_response.status_code, 429)
+        self.assertEqual(second_response.json()["code"], ErrorMessages.TOO_MANY_REQUESTS.name)
+        mock_send_mail.assert_called_once()

--- a/apps/users/tests/test_signup.py
+++ b/apps/users/tests/test_signup.py
@@ -1,14 +1,22 @@
+import datetime
+
 from django.core.cache import cache
 from django.test import TestCase
 from rest_framework.test import APIClient
+
+from apps.core.exceptions.exception_message import ErrorMessages
+from apps.users.models.user import User
 
 
 class SignupAPITestCase(TestCase):
     def setUp(self) -> None:
         self.client = APIClient()
+        self.email = "user@example.com"
+        cache.delete(f"email_code:signup:{self.email}")
+        cache.delete(f"email_code_attempts:signup:{self.email}")
 
     def test_signup_success(self) -> None:
-        email = "user@example.com"
+        email = self.email
         code = "123456"
 
         # signup 전제조건: Redis에 인증코드가 있어야 함
@@ -32,3 +40,100 @@ class SignupAPITestCase(TestCase):
         self.assertEqual(body["nickname"], payload["nickname"])
         self.assertEqual(body["birth_date"], payload["birth_date"])
         self.assertIn("created_at", body)
+
+    def test_signup_returns_conflict_for_existing_email(self) -> None:
+        email = self.email
+        code = "123456"
+        User.objects.create_user(
+            email=email,
+            nickname="existing-user",
+            birth_date=datetime.date(1990, 1, 1),
+            password="Passw0rd!1234",
+        )
+        cache.set(f"email_code:signup:{email}", code, timeout=300)
+
+        payload = {
+            "email": email,
+            "code": code,
+            "password": "Passw0rd!1234",
+            "nickname": "gamer123",
+            "birth_date": "1995-06-15",
+        }
+
+        res = self.client.post("/api/v1/auth/signup/", payload, format="json")
+
+        self.assertEqual(res.status_code, 409)
+        self.assertEqual(res.json()["code"], ErrorMessages.EMAIL_ALREADY_EXISTS.name)
+
+    def test_signup_returns_conflict_for_existing_nickname(self) -> None:
+        email = "user@example.com"
+        code = "123456"
+        User.objects.create_user(
+            email="other@example.com",
+            nickname="gamer123",
+            birth_date=datetime.date(1990, 1, 1),
+            password="Passw0rd!1234",
+        )
+        cache.set(f"email_code:signup:{email}", code, timeout=300)
+
+        payload = {
+            "email": email,
+            "code": code,
+            "password": "Passw0rd!1234",
+            "nickname": "gamer123",
+            "birth_date": "1995-06-15",
+        }
+
+        res = self.client.post("/api/v1/auth/signup/", payload, format="json")
+
+        self.assertEqual(res.status_code, 409)
+        self.assertEqual(res.json()["code"], ErrorMessages.NICKNAME_ALREADY_EXISTS.name)
+
+    def test_signup_returns_code_expired_when_cached_code_missing(self) -> None:
+        payload = {
+            "email": self.email,
+            "code": "123456",
+            "password": "Passw0rd!1234",
+            "nickname": "gamer123",
+            "birth_date": "1995-06-15",
+        }
+
+        res = self.client.post("/api/v1/auth/signup/", payload, format="json")
+
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json()["code"], ErrorMessages.CODE_EXPIRED.name)
+
+    def test_signup_returns_invalid_code_for_mismatched_verification_code(self) -> None:
+        email = self.email
+        cache.set(f"email_code:signup:{email}", "654321", timeout=300)
+
+        payload = {
+            "email": email,
+            "code": "123456",
+            "password": "Passw0rd!1234",
+            "nickname": "gamer123",
+            "birth_date": "1995-06-15",
+        }
+
+        res = self.client.post("/api/v1/auth/signup/", payload, format="json")
+
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json()["code"], ErrorMessages.INVALID_CODE.name)
+
+    def test_signup_returns_validation_error_for_invalid_password(self) -> None:
+        email = self.email
+        code = "123456"
+        cache.set(f"email_code:signup:{email}", code, timeout=300)
+
+        payload = {
+            "email": email,
+            "code": code,
+            "password": "1234",
+            "nickname": "gamer123",
+            "birth_date": "1995-06-15",
+        }
+
+        res = self.client.post("/api/v1/auth/signup/", payload, format="json")
+
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json()["code"], ErrorMessages.VALIDATION_ERROR.name)

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -1,12 +1,13 @@
 from typing import cast
 
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.core.serializers.error_serializer import ErrorResponseSerializer
 from apps.users.models.user import User
 from apps.users.serializers.auth import (
     AccountRestoreRequestSerializer,
@@ -36,7 +37,17 @@ from apps.users.services import (
 @extend_schema(
     summary="회원가입",
     request=SignupRequestSerializer,
-    responses={201: SignupResponseSerializer},
+    responses={
+        201: SignupResponseSerializer,
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="VALIDATION_ERROR, INVALID_CODE, CODE_EXPIRED",
+        ),
+        409: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="EMAIL_ALREADY_EXISTS, NICKNAME_ALREADY_EXISTS",
+        ),
+    },
     tags=["auth"],
 )
 class SignupAPIView(APIView):
@@ -53,7 +64,12 @@ class SignupAPIView(APIView):
 @extend_schema(
     summary="이메일 인증 코드 발송",
     request=EmailCodeSendRequestSerializer,
-    responses={201: EmailCodeSendResponseSerializer},
+    responses={
+        201: EmailCodeSendResponseSerializer,
+        400: OpenApiResponse(response=ErrorResponseSerializer, description="VALIDATION_ERROR"),
+        409: OpenApiResponse(response=ErrorResponseSerializer, description="EMAIL_ALREADY_EXISTS"),
+        429: OpenApiResponse(response=ErrorResponseSerializer, description="TOO_MANY_REQUESTS"),
+    },
     tags=["auth"],
 )
 class EmailCodeSendAPIView(APIView):
@@ -110,7 +126,17 @@ class LoginAPIView(APIView):
 @extend_schema(
     summary="로그아웃",
     request=None,
-    responses={200: MessageResponseSerializer},
+    responses={
+        200: MessageResponseSerializer,
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="INVALID_CODE, VALIDATION_ERROR, SOCIAL_USER_ONLY",
+        ),
+        429: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="TOO_MANY_REQUESTS",
+        ),
+    },
     tags=["auth"],
 )
 class LogoutAPIView(APIView):


### PR DESCRIPTION
## ✅ PR 요약
- 이메일 인증코드 발송 API를 `signup` / `password_reset` 목적에 맞게 분기하고, 관련 Swagger 문서와 테스트를 보강했습니다.

## 📄 상세 내용
- [x] `signup` 목적일 때 이미 가입된 이메일이면 `EMAIL_ALREADY_EXISTS`(409)를 반환하도록 수정했습니다.
- [x] `password_reset` 목적일 때는 기존처럼 이메일 존재 여부를 노출하지 않는 응답 흐름을 유지했습니다.
- [x] 이메일 인증코드 발송 API Swagger 응답에 `400`, `409`, `429` 에러 케이스를 추가했습니다.
- [x] 회원가입 API Swagger 응답에 `VALIDATION_ERROR`, `INVALID_CODE`, `CODE_EXPIRED`, `EMAIL_ALREADY_EXISTS`, `NICKNAME_ALREADY_EXISTS`를 문서화했습니다.
- [x] 비밀번호 재설정 API Swagger 응답에 `INVALID_CODE`, `VALIDATION_ERROR`, `SOCIAL_USER_ONLY`, `TOO_MANY_REQUESTS`를 문서화했습니다.
- [x] 이메일 인증코드 발송 테스트에 기존 이메일/쿨다운 케이스를 추가했습니다.
- [x] 회원가입 테스트에 이메일 중복, 닉네임 중복, 코드 만료, 코드 불일치, 비밀번호 검증 실패 케이스를 추가했습니다.
