### PR TITLE
[Fix/auth/logout-access-token-cookie] 로그아웃 시 access_token 쿠키 삭제 처리

### DIFF
--- a/apps/users/tests/test_logout.py
+++ b/apps/users/tests/test_logout.py
@@ -48,9 +48,7 @@ class LogoutAPITestCase(TestCase):
         self.assertEqual(login_res.status_code, 200)
 
         access_token = login_res.json()["access_token"]
-        refresh_token = login_res.cookies["refresh_token"].value
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
-        self.client.cookies["refresh_token"] = refresh_token
         self.client.cookies["access_token"] = access_token
 
         logout_res = self.client.post(

--- a/apps/users/tests/test_logout.py
+++ b/apps/users/tests/test_logout.py
@@ -39,6 +39,29 @@ class LogoutAPITestCase(TestCase):
         self.assertEqual(logout_res.status_code, 200)
         self.assertEqual(logout_res.json()["message"], "로그아웃 되었습니다.")
 
+    def test_logout_deletes_access_token_cookie(self) -> None:
+        login_res = self.client.post(
+            "/api/v1/auth/login/",
+            {"email": "admin@example.com", "password": "password1100110011"},
+            format="json",
+        )
+        self.assertEqual(login_res.status_code, 200)
+
+        access_token = login_res.json()["access_token"]
+        refresh_token = login_res.cookies["refresh_token"].value
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
+        self.client.cookies["refresh_token"] = refresh_token
+        self.client.cookies["access_token"] = access_token
+
+        logout_res = self.client.post(
+            "/api/v1/auth/logout/",
+            format="json",
+        )
+
+        self.assertEqual(logout_res.status_code, 200)
+        self.assertIn("access_token", logout_res.cookies)
+        self.assertEqual(logout_res.cookies["access_token"].value, "")
+
     def test_logout_without_refresh_token(self) -> None:
         login_res = self.client.post(
             "/api/v1/auth/login/",

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -147,7 +147,8 @@ class LogoutAPIView(APIView):
 
         response_serializer = MessageResponseSerializer({"message": "로그아웃 되었습니다."})
         response = Response(response_serializer.data, status=status.HTTP_200_OK)
-        response.delete_cookie("refresh_token")
+        response.delete_cookie("refresh_token", samesite="None")
+        response.delete_cookie("access_token", samesite="None")
         return response
 
 

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -147,8 +147,8 @@ class LogoutAPIView(APIView):
 
         response_serializer = MessageResponseSerializer({"message": "로그아웃 되었습니다."})
         response = Response(response_serializer.data, status=status.HTTP_200_OK)
-        response.delete_cookie("refresh_token", samesite="None")
-        response.delete_cookie("access_token", samesite="None")
+        response.set_cookie("refresh_token", value="", samesite="None", secure=True, httponly=True, max_age=0)
+        response.set_cookie("access_token", value="", samesite="None", secure=True, httponly=True, max_age=0)
         return response
 
 


### PR DESCRIPTION
## ✅ PR 요약
- 소셜 로그인 후 로그아웃 시 `access_token` 쿠키가 남아 완전히 로그아웃되지 않던 문제를 수정했습니다.

## 📄 상세 내용
- [x] 로그아웃 응답에서 `refresh_token`뿐 아니라 `access_token` 쿠키도 함께 삭제하도록 수정했습니다.
- [x] 쿠키 삭제 시 기존 설정과 맞추기 위해 `SameSite=None` 옵션을 함께 적용했습니다.
- [x] `access_token` 쿠키 삭제 회귀 테스트를 추가했습니다.