### PR TITLE
[Fix/game-list-mapping] 장르 top10 조회 시 DB igdb_id 매핑 및 rating_count 100 이상 필터 적용

### DIFF
--- a/apps/games/igdb/cache.py
+++ b/apps/games/igdb/cache.py
@@ -162,6 +162,36 @@ def search_games(
     cache.set(key, results, _SEARCH_TTL)
     return results
 
+def search_games_by_igdb_genre_id(
+    *,
+    igdb_genre_id: int,
+    sort: str = "rating desc",
+    limit: int = 10,
+    min_rating_count: int = 100,
+) -> list[dict[str, Any]]:
+    params = {
+        "igdb_genre_id": igdb_genre_id,
+        "sort": sort,
+        "limit": limit,
+        "min_rating_count": min_rating_count,
+    }
+    key = _cache_key_search(params)
+
+    cached: list[dict[str, Any]] | None = cache.get(key)
+    if cached is not None:
+        return cached
+
+    client = get_igdb_client()
+    raw_list = client.search_games(
+        genre_ids=[igdb_genre_id],
+        sort=sort,
+        limit=limit,
+        min_rating_count=min_rating_count,
+    )
+
+    results = [build_game_list_item(raw) for raw in raw_list]
+    cache.set(key, results, _SEARCH_TTL)
+    return results
 
 def get_games_by_ids(igdb_ids: list[int]) -> list[dict[str, Any]]:
     if not igdb_ids:

--- a/apps/games/igdb/cache.py
+++ b/apps/games/igdb/cache.py
@@ -183,12 +183,19 @@ def search_games_by_igdb_genre_id(
         return cached
 
     client = get_igdb_client()
-    raw_list = client.search_games(
-        genre_ids=[igdb_genre_id],
-        sort=sort,
-        limit=limit,
-        min_rating_count=min_rating_count,
-    )
+    try:
+        raw_list = client.search_games(
+            genre_ids=[igdb_genre_id],
+            sort=sort,
+            limit=limit,
+            min_rating_count=min_rating_count,
+        )
+    except (IgdbRateLimitError, IgdbServerError):
+        logger.warning("IGDB 호출 실패, stale 캐시 반환 시도")
+        stale: list[dict[str, Any]] | None = cache.get(key)
+        if stale is not None:
+            return stale
+        raise
 
     results = [build_game_list_item(raw) for raw in raw_list]
     cache.set(key, results, _SEARCH_TTL)

--- a/apps/games/igdb/cache.py
+++ b/apps/games/igdb/cache.py
@@ -162,6 +162,7 @@ def search_games(
     cache.set(key, results, _SEARCH_TTL)
     return results
 
+
 def search_games_by_igdb_genre_id(
     *,
     igdb_genre_id: int,
@@ -192,6 +193,7 @@ def search_games_by_igdb_genre_id(
     results = [build_game_list_item(raw) for raw in raw_list]
     cache.set(key, results, _SEARCH_TTL)
     return results
+
 
 def get_games_by_ids(igdb_ids: list[int]) -> list[dict[str, Any]]:
     if not igdb_ids:

--- a/apps/games/igdb/client.py
+++ b/apps/games/igdb/client.py
@@ -272,6 +272,7 @@ class IgdbClient:
         tag_ids: list[int] | None = None,
         theme_ids: list[int] | None = None,
         game_mode_ids: list[int] | None = None,
+        min_rating_count: int | None = None,
         sort: str = "rating desc",
         limit: int = 20,
         offset: int = 0,
@@ -291,6 +292,9 @@ class IgdbClient:
         )
 
         where_parts: list[str] = []
+
+        if min_rating_count:
+            where_parts.append(f"rating_count >= {min_rating_count}")
 
         if genre_ids:
             ids_str = ",".join(str(i) for i in genre_ids)

--- a/apps/games/serializers/game_list.py
+++ b/apps/games/serializers/game_list.py
@@ -44,7 +44,15 @@ class GameListQuerySerializer(serializers.Serializer[dict[str, Any]]):
         return value
 
     def validate_genre_ids(self, value: str | None) -> list[int]:
-        return self._parse_int_list(value)
+        ids = self._parse_int_list(value)
+        if ids:
+            from apps.games.models import Genre
+
+            existing_ids = set(Genre.objects.filter(id__in=ids).values_list("id", flat=True))
+            invalid_ids = [i for i in ids if i not in existing_ids]
+            if invalid_ids:
+                raise CustomAPIException(ErrorMessages.INVALID_GENRE_ID)
+        return ids
 
     def validate_genre_name(self, value: str | None) -> str | None:
         return value

--- a/apps/games/services/game_list.py
+++ b/apps/games/services/game_list.py
@@ -3,6 +3,7 @@ from typing import Any
 from apps.games.igdb import cache as igdb_cache
 from apps.preferences.models import UserGameAffinity
 from apps.users.models import User
+from apps.games.models import Genre
 
 # IGDB 정렬 매핑: API 쿼리 파라미터 → IGDB sort 필드
 _ORDERING_MAP: dict[str, str] = {
@@ -81,11 +82,16 @@ class GameService:
     ) -> list[dict[str, Any]]:
         igdb_sort = _ORDERING_MAP.get(sort, "rating desc")
 
-        # 캐시에서 장르 이름 -> id 조회
-        genre_id = igdb_cache.get_genre_id_by_name(genre_name)
-        if not genre_id:
+        # DB에서 한국어 장르명으로 igdb_id 조회
+        genre = Genre.objects.filter(name=genre_name).first()
+        if not genre or not genre.igdb_id:
             return []
 
-        results = igdb_cache.search_games(genre_ids=[genre_id], sort=igdb_sort, limit=top_n)
+        # rating_count >= 100, 평점순 top10
+        results = igdb_cache.search_games_by_igdb_genre_id(
+            igdb_genre_id=genre.igdb_id,
+            sort=igdb_sort,
+            limit=top_n,
+        )
 
         return GameService.attach_is_saved(results, user)

--- a/apps/games/services/game_list.py
+++ b/apps/games/services/game_list.py
@@ -1,9 +1,9 @@
 from typing import Any
 
 from apps.games.igdb import cache as igdb_cache
+from apps.games.models import Genre
 from apps.preferences.models import UserGameAffinity
 from apps.users.models import User
-from apps.games.models import Genre
 
 # IGDB 정렬 매핑: API 쿼리 파라미터 → IGDB sort 필드
 _ORDERING_MAP: dict[str, str] = {

--- a/apps/games/tests/test_game_list.py
+++ b/apps/games/tests/test_game_list.py
@@ -9,6 +9,7 @@ from rest_framework.test import APITestCase
 
 from apps.core.exceptions.exception_message import ErrorMessages
 from apps.games.services.game_list import GameService
+from apps.games.models import Genre
 
 User = get_user_model()
 
@@ -74,6 +75,13 @@ class GameListViewTests(APITestCase):
         )
         self.url = reverse("game-list")
         self.connection = get_redis_connection("default")
+
+        # 테스트용 장르 생성
+        self.action_genre, _ = Genre.objects.get_or_create(
+            igdb_id=12,
+            igdb_type="genre",
+            defaults={"name": "RPG"},
+        )
 
     def _recent_search_key(self, *, user_id: int) -> str:
         return f"search:recent:{user_id}"
@@ -154,33 +162,25 @@ class GameListViewTests(APITestCase):
         self.assertEqual(second_response.status_code, status.HTTP_200_OK)
         self.assertEqual(self._get_recent_keywords(), ["NoMatch", "Test"])
 
-    @patch("apps.games.services.game_list.igdb_cache.search_games")
-    @patch("apps.games.services.game_list.igdb_cache.get_genre_id_by_name")
-    def test_top_n_by_genre_service_real(self, mock_get_genre_id: MagicMock, mock_search: MagicMock) -> None:
-        mock_get_genre_id.return_value = 12
-        mock_search.return_value = MOCK_TOP10_GAMES
-
-        result = GameService.top_n_by_genre("Action")
+    def test_top_n_by_genre_service_real(self) -> None:
+        with patch("apps.games.services.game_list.igdb_cache.search_games_by_igdb_genre_id") as mock_search:
+            mock_search.return_value = MOCK_TOP10_GAMES
+            result = GameService.top_n_by_genre("RPG")
 
         self.assertEqual(len(result), 10)
         self.assertEqual(result[0]["rawg_rating"], 5.5)
         self.assertAlmostEqual(result[-1]["rawg_rating"], 4.6)
 
-        mock_get_genre_id.return_value = None
-
         result = GameService.top_n_by_genre("NonExistent")
-
         self.assertEqual(result, [])
 
-    @patch("apps.games.services.game_list.igdb_cache.get_genre_id_by_name")
-    @patch("apps.games.services.game_list.igdb_cache.search_games")
-    def test_genre_name_returns_top_n(self, mock_search: MagicMock, mock_get_genre_id: MagicMock) -> None:
-        """genre_name 파라미터로 top_n_by_genre 호출."""
-        mock_get_genre_id.return_value = 12
-        mock_search.return_value = MOCK_TOP10_GAMES
+    def test_genre_name_returns_top_n(self) -> None:
 
-        self.client.force_authenticate(user=self.user)
-        response = self.client.get(self.url, {"genre_name": "Action"})
+        with patch("apps.games.services.game_list.igdb_cache.search_games_by_igdb_genre_id") as mock_search:
+            mock_search.return_value = MOCK_TOP10_GAMES
+
+            self.client.force_authenticate(user=self.user)
+            response = self.client.get(self.url, {"genre_name": "RPG"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 10)

--- a/apps/games/tests/test_game_list.py
+++ b/apps/games/tests/test_game_list.py
@@ -8,8 +8,8 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from apps.core.exceptions.exception_message import ErrorMessages
-from apps.games.services.game_list import GameService
 from apps.games.models import Genre
+from apps.games.services.game_list import GameService
 
 User = get_user_model()
 

--- a/apps/games/tests/test_game_list.py
+++ b/apps/games/tests/test_game_list.py
@@ -77,7 +77,7 @@ class GameListViewTests(APITestCase):
         self.connection = get_redis_connection("default")
 
         # 테스트용 장르 생성
-        self.action_genre, _ = Genre.objects.get_or_create(
+        self.rpg_genre, _ = Genre.objects.get_or_create(
             igdb_id=12,
             igdb_type="genre",
             defaults={"name": "RPG"},

--- a/apps/games/tests/test_igdb_cache.py
+++ b/apps/games/tests/test_igdb_cache.py
@@ -95,6 +95,7 @@ class GetGameDetailTests(TestCase):
         mock_cache.set.assert_called_once()
 
 
+# 일반 검색 테스트
 class SearchGamesTests(TestCase):
     @patch("apps.games.igdb.cache.get_igdb_client")
     @patch("apps.games.igdb.cache.cache")
@@ -177,6 +178,92 @@ class SearchGamesTests(TestCase):
         with self.assertLogs("apps.games.igdb.cache", level="WARNING"):
             with self.assertRaises(IgdbServerError):
                 search_games(query="test")
+
+    @patch("apps.games.igdb.cache._resolve_genre_filters", return_value={})
+    @patch("apps.games.igdb.cache._resolve_tag_filters", return_value={})
+    @patch("apps.games.igdb.cache._resolve_platform_filters", return_value=[])
+    @patch("apps.games.igdb.cache.get_igdb_client")
+    @patch("apps.games.igdb.cache.cache")
+    def test_rate_limit_returns_stale_cache(
+        self,
+        mock_cache: MagicMock,
+        mock_get_client: MagicMock,
+        _rp: MagicMock,
+        _rt: MagicMock,
+        _rg: MagicMock,
+    ) -> None:
+        stale_data = [{"id": 1, "name": "Stale Game"}]
+        mock_cache.get.side_effect = [None, stale_data]
+        mock_client = MagicMock()
+        mock_client.search_games.side_effect = IgdbRateLimitError()
+        mock_get_client.return_value = mock_client
+
+        with self.assertLogs("apps.games.igdb.cache", level="WARNING"):
+            result = search_games(query="test")
+
+        self.assertEqual(result, stale_data)
+
+
+# top10 테스트
+class SearchGamesByIgdbGenreIdTests(TestCase):
+    @patch("apps.games.igdb.cache.get_igdb_client")
+    @patch("apps.games.igdb.cache.cache")
+    def test_returns_cached(self, mock_cache: MagicMock, mock_get_client: MagicMock) -> None:
+        cached_data = [{"id": 1}]
+        mock_cache.get.return_value = cached_data
+        from apps.games.igdb.cache import search_games_by_igdb_genre_id
+
+        result = search_games_by_igdb_genre_id(igdb_genre_id=12)
+        self.assertEqual(result, cached_data)
+        mock_get_client.assert_not_called()
+
+    @patch("apps.games.igdb.cache.get_igdb_client")
+    @patch("apps.games.igdb.cache.cache")
+    def test_fetches_and_caches(self, mock_cache: MagicMock, mock_get_client: MagicMock) -> None:
+        mock_cache.get.return_value = None
+        mock_client = MagicMock()
+        mock_client.search_games.return_value = [
+            {
+                "id": 10,
+                "slug": "g",
+                "name": "G",
+                "rating": 80,
+                "rating_count": 200,
+                "cover": {"image_id": "co1"},
+            }
+        ]
+        mock_get_client.return_value = mock_client
+        from apps.games.igdb.cache import search_games_by_igdb_genre_id
+
+        result = search_games_by_igdb_genre_id(igdb_genre_id=12)
+        self.assertEqual(len(result), 1)
+        mock_cache.set.assert_called_once()
+
+    @patch("apps.games.igdb.cache.get_igdb_client")
+    @patch("apps.games.igdb.cache.cache")
+    def test_rate_limit_reraises_when_no_stale(self, mock_cache: MagicMock, mock_get_client: MagicMock) -> None:
+        mock_cache.get.return_value = None
+        mock_client = MagicMock()
+        mock_client.search_games.side_effect = IgdbRateLimitError()
+        mock_get_client.return_value = mock_client
+        from apps.games.igdb.cache import search_games_by_igdb_genre_id
+
+        with self.assertLogs("apps.games.igdb.cache", level="WARNING"):
+            with self.assertRaises(IgdbRateLimitError):
+                search_games_by_igdb_genre_id(igdb_genre_id=12)
+
+    @patch("apps.games.igdb.cache.get_igdb_client")
+    @patch("apps.games.igdb.cache.cache")
+    def test_server_error_reraises_when_no_stale(self, mock_cache: MagicMock, mock_get_client: MagicMock) -> None:
+        mock_cache.get.return_value = None
+        mock_client = MagicMock()
+        mock_client.search_games.side_effect = IgdbServerError()
+        mock_get_client.return_value = mock_client
+        from apps.games.igdb.cache import search_games_by_igdb_genre_id
+
+        with self.assertLogs("apps.games.igdb.cache", level="WARNING"):
+            with self.assertRaises(IgdbServerError):
+                search_games_by_igdb_genre_id(igdb_genre_id=12)
 
 
 class GetGamesByIdsTests(TestCase):


### PR DESCRIPTION
## ✅ PR 요약
- 장르 top10 조회 시 DB igdb_id 매핑 및 rating_count 100 이상 필터 적용

## 📄 상세 내용
- [x] 장르 top10 조회 시 DB igdb_id 매핑 및 rating_count 100 이상 필터 적용
- [x] 장르 id로 검색시엔 rating_count 제한 없이 일반 검색
- [x] 없는 장르id 검색시 에러메세지 반환

## 🧪 테스트
- [x] 로컬에서 확인했습니다.

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
