### PR TITLE
[Fix/auth/social-logout-cookie] 임시 소셜 로그아웃 쿠키 기반 처리 수정

### DIFF
--- a/apps/users/tests/test_logout.py
+++ b/apps/users/tests/test_logout.py
@@ -60,6 +60,28 @@ class LogoutAPITestCase(TestCase):
         self.assertIn("access_token", logout_res.cookies)
         self.assertEqual(logout_res.cookies["access_token"].value, "")
 
+    def test_logout_with_refresh_token_cookie_only(self) -> None:
+        login_res = self.client.post(
+            "/api/v1/auth/login/",
+            {"email": "admin@example.com", "password": "password1100110011"},
+            format="json",
+        )
+        self.assertEqual(login_res.status_code, 200)
+
+        refresh_token = login_res.cookies["refresh_token"].value
+        self.client.cookies["refresh_token"] = refresh_token
+        self.client.cookies["access_token"] = "social-access-token"
+
+        logout_res = self.client.post(
+            "/api/v1/auth/logout/",
+            format="json",
+        )
+
+        self.assertEqual(logout_res.status_code, 200)
+        self.assertEqual(logout_res.json()["message"], "로그아웃 되었습니다.")
+        self.assertEqual(logout_res.cookies["refresh_token"].value, "")
+        self.assertEqual(logout_res.cookies["access_token"].value, "")
+
     def test_logout_without_refresh_token(self) -> None:
         login_res = self.client.post(
             "/api/v1/auth/login/",

--- a/apps/users/tests/test_logout.py
+++ b/apps/users/tests/test_logout.py
@@ -60,7 +60,7 @@ class LogoutAPITestCase(TestCase):
         self.assertIn("access_token", logout_res.cookies)
         self.assertEqual(logout_res.cookies["access_token"].value, "")
 
-    def test_logout_with_refresh_token_cookie_only(self) -> None:
+    def test_social_logout_with_cookie_tokens(self) -> None:
         login_res = self.client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -2,6 +2,7 @@ from typing import cast
 
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
+from rest_framework.authentication import BaseAuthentication
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -140,7 +141,8 @@ class LoginAPIView(APIView):
     tags=["auth"],
 )
 class LogoutAPIView(APIView):
-    permission_classes = [IsAuthenticated]
+    authentication_classes: tuple[type[BaseAuthentication], ...] = ()
+    permission_classes = [AllowAny]
 
     def post(self, request: Request) -> Response:
         logout_user(request.COOKIES.get("refresh_token"))


### PR DESCRIPTION
## ✅ PR 요약
- 소셜 로그인 사용자가 로그아웃되지 않던 문제를 임시로 해결했습니다.

## 📄 상세 내용
- [x] 로그아웃 API가 `refresh_token` 쿠키만으로도 처리될 수 있도록 수정했습니다.
- [x] 로그아웃 시 `refresh_token`, `access_token` 쿠키를 모두 만료 처리하도록 수정했습니다.
- [x] 소셜 로그인과 유사한 쿠키 기반 로그아웃 시나리오 테스트를 추가했습니다.
- [x] 기존 일반 로그인 로그아웃 동작이 유지되는지도 함께 검증했습니다.


## 참고
- 본 PR은 소셜 로그아웃이 동작하지 않는 현재 이슈를 우선 막기 위한 임시 대응입니다.
- 일반 로그인/소셜 로그인 인증 구조 차이로 인한 세션 복구 및 보안 정책 정리는 별도 논의가 필요합니다.