### PR TITLE
[Feature/admin/{user_id}/recommendations] 어드민 추천 결과 조회 API 추가

### DIFF
--- a/apps/recommendations/serializers.py
+++ b/apps/recommendations/serializers.py
@@ -142,3 +142,15 @@ class RecommendationJobRunResponseSerializer(serializers.Serializer):  # type: i
     type = serializers.CharField(source="job_type")
     status = serializers.CharField()
     created_at = serializers.DateTimeField()
+
+
+class AdminUserRecommendationItemSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    game_id = serializers.IntegerField(source="igdb_game_id")
+    score = serializers.FloatField()
+
+
+class AdminUserRecommendationListResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    count = serializers.IntegerField()
+    next = serializers.CharField(allow_null=True)
+    previous = serializers.CharField(allow_null=True)
+    results = AdminUserRecommendationItemSerializer(many=True)

--- a/apps/recommendations/serializers.py
+++ b/apps/recommendations/serializers.py
@@ -146,7 +146,7 @@ class RecommendationJobRunResponseSerializer(serializers.Serializer):  # type: i
 
 class AdminUserRecommendationItemSerializer(serializers.Serializer):  # type: ignore[type-arg]
     game_id = serializers.IntegerField(source="igdb_game_id")
-    score = serializers.FloatField()
+    score = serializers.DecimalField(max_digits=5, decimal_places=4)
 
 
 class AdminUserRecommendationListResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]

--- a/apps/recommendations/services.py
+++ b/apps/recommendations/services.py
@@ -101,6 +101,10 @@ class RecommendationService:
 
 class RecommendationAdminService:
     @staticmethod
+    def list_user_recommendations(*, user_id: int) -> QuerySet[UserRecommendation]:
+        return UserRecommendation.objects.filter(user_id=user_id).order_by("rank")
+
+    @staticmethod
     def list_recommendation_jobs(
         *,
         job_status: str | None = None,

--- a/apps/recommendations/views_admin.py
+++ b/apps/recommendations/views_admin.py
@@ -404,8 +404,8 @@ class AdminRecommendationJobRunView(APIView):
                 "next": "http://example.com/api/v1/admin/users/1/recommendations/?page=2",
                 "previous": None,
                 "results": [
-                    {"game_id": 12345, "score": 120.5},
-                    {"game_id": 67890, "score": 98.2},
+                    {"game_id": 12345, "score": "120.5000"},
+                    {"game_id": 67890, "score": "98.2000"},
                 ],
             },
             response_only=True,
@@ -417,8 +417,7 @@ class AdminUserRecommendationListView(APIView):
     permission_classes = [IsStaffAdmin]
 
     def get(self, request: Request, user_id: int) -> Response:
-        target_user = User.objects.filter(pk=user_id).first()
-        if target_user is None:
+        if not User.objects.filter(pk=user_id).exists():
             raise CustomAPIException(ErrorMessages.USER_NOT_FOUND)
 
         qs = RecommendationAdminService.list_user_recommendations(user_id=user_id)

--- a/apps/recommendations/views_admin.py
+++ b/apps/recommendations/views_admin.py
@@ -13,10 +13,13 @@ from rest_framework.views import APIView
 
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.core.exceptions.exception_message import ErrorMessages
+from apps.core.permissions import IsStaffAdmin
 from apps.core.serializers.error_serializer import ErrorResponseSerializer
 from apps.core.utils.pagination import PAGINATION_PARAMS, Pagination
 from apps.recommendations.models import RecommendationJob
 from apps.recommendations.serializers import (
+    AdminUserRecommendationItemSerializer,
+    AdminUserRecommendationListResponseSerializer,
     RecommendationJobDetailResponseSerializer,
     RecommendationJobItemSerializer,
     RecommendationJobListQuerySerializer,
@@ -329,3 +332,97 @@ class AdminRecommendationJobRunView(APIView):
 
         serializer = RecommendationJobRunResponseSerializer(job)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+@extend_schema(
+    tags=["admin"],
+    summary="어드민 - 특정 유저 추천 결과 조회",
+    description=(
+        "관리자(staff) 전용 API입니다. path의 유저 ID에 해당하는 추천 결과 목록을 페이지네이션으로 조회합니다. "
+        "추천 디버깅용으로 사용합니다. 각 항목은 game_id(IGDB 게임 ID)와 score를 반환합니다."
+    ),
+    parameters=[
+        OpenApiParameter(
+            name="user_id",
+            type=int,
+            location=OpenApiParameter.PATH,
+            required=True,
+            description="추천 결과를 조회할 유저의 ID (user pk)",
+        ),
+        *PAGINATION_PARAMS,
+    ],
+    responses={
+        200: AdminUserRecommendationListResponseSerializer,
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="인증되지 않음. Authorization 헤더에 유효한 Bearer 토큰이 필요합니다.",
+            examples=[
+                OpenApiExample(
+                    "인증 필요",
+                    value={
+                        "status_code": ErrorMessages.UNAUTHORIZED.status_code,
+                        "code": ErrorMessages.UNAUTHORIZED.name,
+                        "message": ErrorMessages.UNAUTHORIZED.message,
+                    },
+                )
+            ],
+        ),
+        403: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="권한 없음. is_staff=True인 관리자만 호출할 수 있습니다.",
+            examples=[
+                OpenApiExample(
+                    "관리자 권한 필요",
+                    value={
+                        "status_code": ErrorMessages.FORBIDDEN.status_code,
+                        "code": ErrorMessages.FORBIDDEN.name,
+                        "message": ErrorMessages.FORBIDDEN.message,
+                    },
+                )
+            ],
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="해당 ID의 사용자를 찾을 수 없음.",
+            examples=[
+                OpenApiExample(
+                    "USER_NOT_FOUND",
+                    value={
+                        "status_code": ErrorMessages.USER_NOT_FOUND.status_code,
+                        "code": ErrorMessages.USER_NOT_FOUND.name,
+                        "message": ErrorMessages.USER_NOT_FOUND.message,
+                    },
+                )
+            ],
+        ),
+    },
+    examples=[
+        OpenApiExample(
+            "성공 시 응답 예시",
+            value={
+                "count": 20,
+                "next": "http://example.com/api/v1/admin/users/1/recommendations/?page=2",
+                "previous": None,
+                "results": [
+                    {"game_id": 12345, "score": 120.5},
+                    {"game_id": 67890, "score": 98.2},
+                ],
+            },
+            response_only=True,
+            status_codes=["200"],
+        )
+    ],
+)
+class AdminUserRecommendationListView(APIView):
+    permission_classes = [IsStaffAdmin]
+
+    def get(self, request: Request, user_id: int) -> Response:
+        target_user = User.objects.filter(pk=user_id).first()
+        if target_user is None:
+            raise CustomAPIException(ErrorMessages.USER_NOT_FOUND)
+
+        qs = RecommendationAdminService.list_user_recommendations(user_id=user_id)
+        paginator = Pagination()
+        page = paginator.paginate_queryset(qs, request)
+        serializer = AdminUserRecommendationItemSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)

--- a/apps/users/urls_admin.py
+++ b/apps/users/urls_admin.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from apps.recommendations.views_admin import AdminUserRecommendationListView
 from apps.users.views_admin import (
     AdminDashboardSummaryAPIView,
     AdminUserDetailAPIView,
@@ -10,4 +11,9 @@ urlpatterns = [
     path("dashboard/", AdminDashboardSummaryAPIView.as_view(), name="admin-dashboard-summary"),
     path("", AdminUserListAPIView.as_view(), name="admin-user-list"),
     path("<int:user_id>/", AdminUserDetailAPIView.as_view(), name="admin-user-detail"),
+    path(
+        "<int:user_id>/recommendations/",
+        AdminUserRecommendationListView.as_view(),
+        name="admin-user-recommendation-list",
+    ),
 ]


### PR DESCRIPTION
## ✅ PR 요약
- staff 전용으로 특정 유저의 추천 목록(`game_id`, `score`)을 페이지네이션으로 조회하는 API를 추가했습니다

## 📄 상세 내용
- [x] GET /api/v1/admin/users/{user_id}/recommendations/ 라우트 추가 (apps.users.urls_admin + AdminUserRecommendationListView)
- [x] RecommendationAdminService.list_user_recommendations 및 응답 시리얼라이저, extend_schema (admin 태그·파라미터·에러 예시) 적용
- [x] IsStaffAdmin 권한으로 인증·staff 검증 (비 staff 시 FORBIDDEN 공통 포맷)

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] 빌드/린트가 통과합니다. (가능한 경우)

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
