### PR TITLE
[Feature/auth/cookie-unification] 일반 로그인과 소셜 로그인 쿠키 기반 인증 구조 통일

### DIFF
--- a/apps/core/auth_utils.py
+++ b/apps/core/auth_utils.py
@@ -1,0 +1,75 @@
+from datetime import timedelta
+from typing import Any, Literal, TypedDict, cast
+
+from django.conf import settings
+from django.http.response import HttpResponseBase
+from django.middleware.csrf import get_token
+from rest_framework.authentication import CSRFCheck
+from rest_framework.exceptions import APIException
+from rest_framework.request import Request
+
+from apps.core.exceptions.exception_message import ErrorMessages
+
+
+class AuthCookieOptions(TypedDict):
+    httponly: bool
+    samesite: Literal["None"]
+    secure: bool
+
+
+class CSRFCookieOptions(TypedDict):
+    samesite: Literal["None"]
+    secure: bool
+
+
+AUTH_COOKIE_OPTIONS: AuthCookieOptions = {
+    "httponly": True,
+    "samesite": "None",
+    "secure": True,
+}
+
+CSRF_COOKIE_OPTIONS: CSRFCookieOptions = {
+    "samesite": "None",
+    "secure": True,
+}
+
+
+class CSRFFailedAPIException(APIException):
+    def __init__(self) -> None:
+        self.status_code = ErrorMessages.CSRF_FAILED.status_code
+        self.detail = cast(
+            dict[str, Any],
+            {
+                "status_code": ErrorMessages.CSRF_FAILED.status_code,
+                "code": ErrorMessages.CSRF_FAILED.name,
+                "message": ErrorMessages.CSRF_FAILED.message,
+            },
+        )
+
+
+def enforce_csrf(request: Request) -> None:
+    check = CSRFCheck(request)  # type: ignore[arg-type]
+    check.process_request(request)
+    reason = check.process_view(request, lambda r: None, (), {})  # type: ignore[arg-type, return-value]
+    if reason:
+        raise CSRFFailedAPIException()
+
+
+def set_access_token_cookie(*, response: HttpResponseBase, access_token: str, expires_in: int) -> None:
+    response.set_cookie("access_token", value=access_token, max_age=expires_in, **AUTH_COOKIE_OPTIONS)
+
+
+def set_refresh_token_cookie(*, response: HttpResponseBase, refresh_token: str) -> None:
+    refresh_max_age = int(cast(timedelta, settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"]).total_seconds())
+    response.set_cookie("refresh_token", value=refresh_token, max_age=refresh_max_age, **AUTH_COOKIE_OPTIONS)
+
+
+def set_csrf_cookie(*, request: Request, response: HttpResponseBase) -> str:
+    csrf_token = get_token(request)
+    response.set_cookie("csrftoken", value=csrf_token, **CSRF_COOKIE_OPTIONS)
+    return csrf_token
+
+
+def expire_auth_cookies(*, response: HttpResponseBase) -> None:
+    response.set_cookie("refresh_token", value="", max_age=0, **AUTH_COOKIE_OPTIONS)
+    response.set_cookie("access_token", value="", max_age=0, **AUTH_COOKIE_OPTIONS)

--- a/apps/core/authentication.py
+++ b/apps/core/authentication.py
@@ -1,13 +1,13 @@
-from rest_framework.authentication import CSRFCheck
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework_simplejwt.authentication import AuthUser, JWTAuthentication
 from rest_framework_simplejwt.tokens import Token
 
+from apps.core.auth_utils import enforce_csrf
+
 
 class CookieJWTAuthentication(JWTAuthentication):
     """
-    Authorization 헤더 우선, 없으면 access_token HttpOnly 쿠키에서 읽습니다.
+    Authorization header 우선, 없으면 access_token HttpOnly 쿠키에서 읽습니다.
     쿠키 기반 인증 시 CSRF 검사를 강제합니다.
     """
 
@@ -20,13 +20,6 @@ class CookieJWTAuthentication(JWTAuthentication):
         if raw_token is None:
             return None
 
-        self._enforce_csrf(request)
+        enforce_csrf(request)
         validated_token = self.get_validated_token(raw_token.encode())
         return self.get_user(validated_token), validated_token  # type: ignore[return-value]
-
-    def _enforce_csrf(self, request: Request) -> None:
-        check = CSRFCheck(request)  # type: ignore[arg-type]
-        check.process_request(request)
-        reason = check.process_view(request, lambda r: None, (), {})  # type: ignore[arg-type, return-value]
-        if reason:
-            raise PermissionDenied(f"CSRF 검사 실패: {reason}")

--- a/apps/core/exceptions/exception_message.py
+++ b/apps/core/exceptions/exception_message.py
@@ -57,6 +57,7 @@ class ErrorMessages(Enum):
 
     # 403 Forbidden
     FORBIDDEN = (403, "관리자 권한이 필요합니다.")
+    CSRF_FAILED = (403, "CSRF 검증에 실패했습니다.")
     ADULT_VERIFICATION_REQUIRED = (403, "성인 인증이 필요한 게임입니다.")
 
     # 404 Not Found

--- a/apps/users/serializers/auth.py
+++ b/apps/users/serializers/auth.py
@@ -59,6 +59,10 @@ class MessageResponseSerializer(serializers.Serializer):  # type: ignore[type-ar
     message = serializers.CharField()
 
 
+class CSRFTokenResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    csrf_token = serializers.CharField()
+
+
 class AuthMeResponseSerializer(serializers.ModelSerializer[User]):
     class Meta:
         model = User

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import secrets
 from datetime import date, timedelta
+from typing import cast
 
 from django.conf import settings
 from django.contrib.auth.password_validation import validate_password
@@ -191,7 +192,7 @@ def logout_user(refresh_token: str | None) -> None:
         raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN) from err
 
 
-def refresh_access_token(refresh_token: str | None) -> tuple[str, int]:
+def refresh_access_token(refresh_token: str | None) -> tuple[str, str, int]:
     if not refresh_token:
         raise CustomAPIException(ErrorMessages.REFRESH_TOKEN_MISSING)
 
@@ -206,6 +207,11 @@ def refresh_access_token(refresh_token: str | None) -> tuple[str, int]:
             raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN)
         get_active_user_or_deactivated(user)
 
+        if cast(bool, settings.SIMPLE_JWT["ROTATE_REFRESH_TOKENS"]):
+            if cast(bool, settings.SIMPLE_JWT["BLACKLIST_AFTER_ROTATION"]):
+                refresh.blacklist()
+            return issue_auth_tokens(user)
+
         access = refresh.access_token
     except TokenError as err:
         message = str(err)
@@ -213,4 +219,4 @@ def refresh_access_token(refresh_token: str | None) -> tuple[str, int]:
             raise CustomAPIException(ErrorMessages.REFRESH_TOKEN_EXPIRED) from err
         raise CustomAPIException(ErrorMessages.INVALID_REFRESH_TOKEN) from err
 
-    return str(access), int(access.lifetime.total_seconds())
+    return str(access), str(refresh), int(access.lifetime.total_seconds())

--- a/apps/users/tests/test_auth_me.py
+++ b/apps/users/tests/test_auth_me.py
@@ -13,7 +13,7 @@ from apps.core.exceptions.exception_message import ErrorMessages
 
 class AuthMeAPITestCase(TestCase):
     def setUp(self) -> None:
-        self.client = APIClient()
+        self.client: APIClient = APIClient(enforce_csrf_checks=True)
         self.user = get_user_model().objects.create_user(
             email="authme@example.com",
             password="Passw0rd!",
@@ -22,7 +22,15 @@ class AuthMeAPITestCase(TestCase):
         )
         self.url = reverse("auth-me")
 
+    def _set_csrf_header(self) -> str:
+        response = self.client.get("/api/v1/auth/csrf/")
+        self.assertEqual(response.status_code, 200)
+        csrf_token = str(response.json()["csrf_token"])
+        self.client.credentials(HTTP_X_CSRFTOKEN=csrf_token)
+        return csrf_token
+
     def test_auth_me_returns_current_user_info_from_login_cookie(self) -> None:
+        self._set_csrf_header()
         login_response = self.client.post(
             "/api/v1/auth/login/",
             {"email": "authme@example.com", "password": "Passw0rd!"},

--- a/apps/users/tests/test_auth_me.py
+++ b/apps/users/tests/test_auth_me.py
@@ -22,11 +22,15 @@ class AuthMeAPITestCase(TestCase):
         )
         self.url = reverse("auth-me")
 
-    def test_auth_me_returns_current_user_info(self) -> None:
-        client = APIClient()
-        client.force_authenticate(user=self.user)
+    def test_auth_me_returns_current_user_info_from_login_cookie(self) -> None:
+        login_response = self.client.post(
+            "/api/v1/auth/login/",
+            {"email": "authme@example.com", "password": "Passw0rd!"},
+            format="json",
+        )
+        self.assertEqual(login_response.status_code, 200)
 
-        res = client.get(self.url)
+        res = self.client.get(self.url)
         drf_res = cast(Response, res)
 
         self.assertEqual(drf_res.status_code, 200)

--- a/apps/users/tests/test_discord_callback.py
+++ b/apps/users/tests/test_discord_callback.py
@@ -46,6 +46,7 @@ class DiscordCallbackAPITestCase(TestCase):
         self.assertEqual(params["is_new_user"], "true")
         self.assertEqual(response.cookies["access_token"].value, "test-access-token")
         self.assertEqual(response.cookies["refresh_token"].value, "test-refresh-token")
+        self.assertTrue(response.cookies["csrftoken"].value)
 
     @patch("apps.users.views.social_auth.handle_discord_callback")
     def test_discord_callback_redirects_with_access_token_for_existing_user(self, mock_handle: MagicMock) -> None:
@@ -65,6 +66,7 @@ class DiscordCallbackAPITestCase(TestCase):
         self.assertEqual(params["is_new_user"], "false")
         self.assertEqual(response.cookies["access_token"].value, "test-access-token")
         self.assertEqual(response.cookies["refresh_token"].value, "test-refresh-token")
+        self.assertTrue(response.cookies["csrftoken"].value)
 
     @patch("apps.users.views.social_auth.handle_discord_callback")
     def test_discord_callback_redirects_with_error_on_server_exception(self, mock_handle: MagicMock) -> None:

--- a/apps/users/tests/test_kakao_callback.py
+++ b/apps/users/tests/test_kakao_callback.py
@@ -45,6 +45,7 @@ class KakaoCallbackAPITestCase(TestCase):
         self.assertEqual(params["is_new_user"], "true")
         self.assertEqual(response.cookies["access_token"].value, "test-access-token")
         self.assertEqual(response.cookies["refresh_token"].value, "test-refresh-token")
+        self.assertTrue(response.cookies["csrftoken"].value)
 
     @patch("apps.users.views.social_auth.handle_kakao_callback")
     def test_kakao_callback_redirects_with_access_token_for_existing_user(self, mock_handle: MagicMock) -> None:
@@ -64,6 +65,7 @@ class KakaoCallbackAPITestCase(TestCase):
         self.assertEqual(params["is_new_user"], "false")
         self.assertEqual(response.cookies["access_token"].value, "test-access-token")
         self.assertEqual(response.cookies["refresh_token"].value, "test-refresh-token")
+        self.assertTrue(response.cookies["csrftoken"].value)
 
     @patch("apps.users.views.social_auth.handle_kakao_callback")
     def test_kakao_callback_redirects_with_error_on_server_exception(self, mock_handle: MagicMock) -> None:

--- a/apps/users/tests/test_login.py
+++ b/apps/users/tests/test_login.py
@@ -18,26 +18,33 @@ class LoginAPITestCase(TestCase):
             password="password1100110011",
         )
 
-    def test_login(self) -> None:
-        # 로그인 요청
+    def test_login_sets_auth_and_csrf_cookies(self) -> None:
         res = self.client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
             format="json",
         )
 
-        # 성공 응답
         self.assertEqual(res.status_code, 200)
-
-        data = res.json()
-        self.assertIn("access_token", data)
-        self.assertTrue(data["access_token"])  # 빈 문자열/None이면 실패
-        self.assertEqual(data["token_type"], "Bearer")
-        self.assertEqual(data["expires_in"], 3600)
+        self.assertEqual(res.json()["message"], "로그인 되었습니다.")
+        self.assertIn("access_token", res.cookies)
         self.assertIn("refresh_token", res.cookies)
+        self.assertIn("csrftoken", res.cookies)
+        self.assertTrue(res.cookies["access_token"].value)
+        self.assertTrue(res.cookies["refresh_token"].value)
+        self.assertTrue(res.cookies["csrftoken"].value)
+        self.assertTrue(res.cookies["access_token"]["httponly"])
         self.assertTrue(res.cookies["refresh_token"]["httponly"])
 
-    # 비밀번호 오류
+    def test_auth_csrf_returns_token_and_cookie(self) -> None:
+        res = self.client.get("/api/v1/auth/csrf/")
+
+        self.assertEqual(res.status_code, 200)
+        self.assertIn("csrf_token", res.json())
+        self.assertIn("csrftoken", res.cookies)
+        self.assertTrue(res.json()["csrf_token"])
+        self.assertTrue(res.cookies["csrftoken"].value)
+
     def test_login_invalid_password(self) -> None:
         res = self.client.post(
             "/api/v1/auth/login/",
@@ -45,12 +52,9 @@ class LoginAPITestCase(TestCase):
             format="json",
         )
 
-        # 실패 응답
         self.assertEqual(res.status_code, 401)
-        data = res.json()
-        self.assertEqual(data["code"], ErrorMessages.INVALID_CREDENTIALS.name)
+        self.assertEqual(res.json()["code"], ErrorMessages.INVALID_CREDENTIALS.name)
 
-    # 이메일 오류
     def test_login_none_email(self) -> None:
         res = self.client.post(
             "/api/v1/auth/login/",
@@ -58,10 +62,8 @@ class LoginAPITestCase(TestCase):
             format="json",
         )
 
-        # 실패 응답
         self.assertEqual(res.status_code, 401)
-        data = res.json()
-        self.assertEqual(data["code"], ErrorMessages.INVALID_CREDENTIALS.name)
+        self.assertEqual(res.json()["code"], ErrorMessages.INVALID_CREDENTIALS.name)
 
     def test_login_deleted_user_returns_401(self) -> None:
         self.user.deleted_at = timezone.now()

--- a/apps/users/tests/test_login.py
+++ b/apps/users/tests/test_login.py
@@ -10,7 +10,7 @@ from apps.users.models.user import User
 
 class LoginAPITestCase(TestCase):
     def setUp(self) -> None:
-        self.client = APIClient()
+        self.client: APIClient = APIClient(enforce_csrf_checks=True)
         self.user = User.objects.create_user(
             email="admin@example.com",
             nickname="admin",
@@ -18,7 +18,15 @@ class LoginAPITestCase(TestCase):
             password="password1100110011",
         )
 
+    def _set_csrf_header(self) -> str:
+        response = self.client.get("/api/v1/auth/csrf/")
+        self.assertEqual(response.status_code, 200)
+        csrf_token = str(response.json()["csrf_token"])
+        self.client.credentials(HTTP_X_CSRFTOKEN=csrf_token)
+        return csrf_token
+
     def test_login_sets_auth_and_csrf_cookies(self) -> None:
+        self._set_csrf_header()
         res = self.client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
@@ -36,6 +44,16 @@ class LoginAPITestCase(TestCase):
         self.assertTrue(res.cookies["access_token"]["httponly"])
         self.assertTrue(res.cookies["refresh_token"]["httponly"])
 
+    def test_login_requires_csrf(self) -> None:
+        res = self.client.post(
+            "/api/v1/auth/login/",
+            {"email": "admin@example.com", "password": "password1100110011"},
+            format="json",
+        )
+
+        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.json()["code"], ErrorMessages.CSRF_FAILED.name)
+
     def test_auth_csrf_returns_token_and_cookie(self) -> None:
         res = self.client.get("/api/v1/auth/csrf/")
 
@@ -46,6 +64,7 @@ class LoginAPITestCase(TestCase):
         self.assertTrue(res.cookies["csrftoken"].value)
 
     def test_login_invalid_password(self) -> None:
+        self._set_csrf_header()
         res = self.client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "oh.no"},
@@ -56,6 +75,7 @@ class LoginAPITestCase(TestCase):
         self.assertEqual(res.json()["code"], ErrorMessages.INVALID_CREDENTIALS.name)
 
     def test_login_none_email(self) -> None:
+        self._set_csrf_header()
         res = self.client.post(
             "/api/v1/auth/login/",
             {"email": "nonexistent@example.com", "password": "oh.no"},
@@ -70,6 +90,7 @@ class LoginAPITestCase(TestCase):
         self.user.is_active = False
         self.user.save(update_fields=["deleted_at", "is_active"])
 
+        self._set_csrf_header()
         res = self.client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},

--- a/apps/users/tests/test_logout.py
+++ b/apps/users/tests/test_logout.py
@@ -41,18 +41,16 @@ class LogoutAPITestCase(TestCase):
         self.assertEqual(logout_res.cookies["access_token"].value, "")
 
     def test_logout_deletes_access_token_cookie(self) -> None:
-        login_res = self.client.post(
+        login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
             format="json",
         )
         self.assertEqual(login_res.status_code, 200)
 
-        access_token = login_res.json()["access_token"]
-        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
-        self.client.cookies["access_token"] = access_token
+        self._set_csrf_header()
 
-        logout_res = self.client.post(
+        logout_res = self.api_client.post(
             "/api/v1/auth/logout/",
             format="json",
         )

--- a/apps/users/tests/test_logout.py
+++ b/apps/users/tests/test_logout.py
@@ -3,12 +3,13 @@ import datetime
 from django.test import TestCase
 from rest_framework.test import APIClient
 
+from apps.core.exceptions.exception_message import ErrorMessages
 from apps.users.models.user import User
 
 
 class LogoutAPITestCase(TestCase):
     def setUp(self) -> None:
-        self.client: APIClient = APIClient()
+        self.api_client = APIClient(enforce_csrf_checks=True)
         self.user = User.objects.create_user(
             email="admin@example.com",
             nickname="admin",
@@ -16,28 +17,28 @@ class LogoutAPITestCase(TestCase):
             password="password1100110011",
         )
 
-    def test_logout(self) -> None:
-        login_res = self.client.post(
+    def _set_csrf_header(self) -> str:
+        response = self.api_client.get("/api/v1/auth/csrf/")
+        self.assertEqual(response.status_code, 200)
+        csrf_token = str(response.json()["csrf_token"])
+        self.api_client.credentials(HTTP_X_CSRFTOKEN=csrf_token)
+        return csrf_token
+
+    def test_logout_clears_auth_cookies(self) -> None:
+        login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
             format="json",
         )
         self.assertEqual(login_res.status_code, 200)
 
-        data = login_res.json()
-        self.assertIn("access_token", data)
-        self.assertIn("refresh_token", login_res.cookies)
-
-        access_token = data["access_token"]
-        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
-
-        logout_res = self.client.post(
-            "/api/v1/auth/logout/",
-            format="json",
-        )
+        self._set_csrf_header()
+        logout_res = self.api_client.post("/api/v1/auth/logout/", format="json")
 
         self.assertEqual(logout_res.status_code, 200)
         self.assertEqual(logout_res.json()["message"], "로그아웃 되었습니다.")
+        self.assertEqual(logout_res.cookies["refresh_token"].value, "")
+        self.assertEqual(logout_res.cookies["access_token"].value, "")
 
     def test_logout_deletes_access_token_cookie(self) -> None:
         login_res = self.client.post(
@@ -61,21 +62,29 @@ class LogoutAPITestCase(TestCase):
         self.assertEqual(logout_res.cookies["access_token"].value, "")
 
     def test_logout_without_refresh_token(self) -> None:
-        login_res = self.client.post(
+        login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
             format="json",
         )
         self.assertEqual(login_res.status_code, 200)
 
-        access_token = login_res.json()["access_token"]
-        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
-        self.client.cookies.pop("refresh_token", None)
-
-        res = self.client.post(
-            "/api/v1/auth/logout/",
-            format="json",
-        )
+        self.api_client.cookies.pop("refresh_token", None)
+        self._set_csrf_header()
+        res = self.api_client.post("/api/v1/auth/logout/", format="json")
 
         self.assertEqual(res.status_code, 400)
         self.assertEqual(res.json()["code"], "REFRESH_TOKEN_MISSING")
+
+    def test_logout_requires_csrf(self) -> None:
+        login_res = self.api_client.post(
+            "/api/v1/auth/login/",
+            {"email": "admin@example.com", "password": "password1100110011"},
+            format="json",
+        )
+        self.assertEqual(login_res.status_code, 200)
+
+        res = self.api_client.post("/api/v1/auth/logout/", format="json")
+
+        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.json()["code"], ErrorMessages.CSRF_FAILED.name)

--- a/apps/users/tests/test_logout.py
+++ b/apps/users/tests/test_logout.py
@@ -25,6 +25,7 @@ class LogoutAPITestCase(TestCase):
         return csrf_token
 
     def test_logout_clears_auth_cookies(self) -> None:
+        self._set_csrf_header()
         login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
@@ -41,6 +42,7 @@ class LogoutAPITestCase(TestCase):
         self.assertEqual(logout_res.cookies["access_token"].value, "")
 
     def test_logout_deletes_access_token_cookie(self) -> None:
+        self._set_csrf_header()
         login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
@@ -49,17 +51,14 @@ class LogoutAPITestCase(TestCase):
         self.assertEqual(login_res.status_code, 200)
 
         self._set_csrf_header()
-
-        logout_res = self.api_client.post(
-            "/api/v1/auth/logout/",
-            format="json",
-        )
+        logout_res = self.api_client.post("/api/v1/auth/logout/", format="json")
 
         self.assertEqual(logout_res.status_code, 200)
         self.assertIn("access_token", logout_res.cookies)
         self.assertEqual(logout_res.cookies["access_token"].value, "")
 
     def test_logout_without_refresh_token(self) -> None:
+        self._set_csrf_header()
         login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
@@ -75,12 +74,14 @@ class LogoutAPITestCase(TestCase):
         self.assertEqual(res.json()["code"], "REFRESH_TOKEN_MISSING")
 
     def test_logout_requires_csrf(self) -> None:
+        self._set_csrf_header()
         login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
             format="json",
         )
         self.assertEqual(login_res.status_code, 200)
+        self.api_client.credentials()
 
         res = self.api_client.post("/api/v1/auth/logout/", format="json")
 

--- a/apps/users/tests/test_refresh.py
+++ b/apps/users/tests/test_refresh.py
@@ -23,7 +23,8 @@ class RefreshAPITestCase(TestCase):
         self.api_client.credentials(HTTP_X_CSRFTOKEN=csrf_token)
         return csrf_token
 
-    def test_refresh_updates_access_token_cookie(self) -> None:
+    def test_refresh_updates_auth_cookies(self) -> None:
+        self._set_csrf_header()
         login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
@@ -31,6 +32,7 @@ class RefreshAPITestCase(TestCase):
         )
         self.assertEqual(login_res.status_code, 200)
         old_access_token = login_res.cookies["access_token"].value
+        old_refresh_token = login_res.cookies["refresh_token"].value
 
         self._set_csrf_header()
         res = self.api_client.post("/api/v1/auth/refresh/", format="json")
@@ -38,9 +40,12 @@ class RefreshAPITestCase(TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.json()["message"], "액세스 토큰이 갱신되었습니다.")
         self.assertIn("access_token", res.cookies)
+        self.assertIn("refresh_token", res.cookies)
         self.assertIn("csrftoken", res.cookies)
         self.assertTrue(res.cookies["access_token"].value)
+        self.assertTrue(res.cookies["refresh_token"].value)
         self.assertNotEqual(res.cookies["access_token"].value, old_access_token)
+        self.assertNotEqual(res.cookies["refresh_token"].value, old_refresh_token)
 
     def test_refresh_without_refresh_token(self) -> None:
         self._set_csrf_header()
@@ -59,6 +64,7 @@ class RefreshAPITestCase(TestCase):
         self.assertEqual(res.json()["code"], "INVALID_REFRESH_TOKEN")
 
     def test_refresh_with_deactivated_user(self) -> None:
+        self._set_csrf_header()
         login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
@@ -76,6 +82,7 @@ class RefreshAPITestCase(TestCase):
         self.assertEqual(res.json()["code"], "ACCOUNT_DEACTIVATED")
 
     def test_refresh_ignores_invalid_access_token_cookie(self) -> None:
+        self._set_csrf_header()
         login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},

--- a/apps/users/tests/test_refresh.py
+++ b/apps/users/tests/test_refresh.py
@@ -1,8 +1,5 @@
 import datetime
-from datetime import timedelta
-from typing import cast
 
-from django.conf import settings
 from django.test import TestCase
 from rest_framework.test import APIClient
 
@@ -11,7 +8,7 @@ from apps.users.models.user import User
 
 class RefreshAPITestCase(TestCase):
     def setUp(self) -> None:
-        self.client = APIClient()
+        self.api_client = APIClient(enforce_csrf_checks=True)
         self.user = User.objects.create_user(
             email="admin@example.com",
             nickname="admin",
@@ -19,60 +16,50 @@ class RefreshAPITestCase(TestCase):
             password="password1100110011",
         )
 
-    def test_refresh(self) -> None:
-        login_res = self.client.post(
+    def _set_csrf_header(self) -> str:
+        response = self.api_client.get("/api/v1/auth/csrf/")
+        self.assertEqual(response.status_code, 200)
+        csrf_token = str(response.json()["csrf_token"])
+        self.api_client.credentials(HTTP_X_CSRFTOKEN=csrf_token)
+        return csrf_token
+
+    def test_refresh_updates_access_token_cookie(self) -> None:
+        login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
             format="json",
         )
         self.assertEqual(login_res.status_code, 200)
-        self.assertIn("refresh_token", login_res.cookies)
+        old_access_token = login_res.cookies["access_token"].value
 
-        res = self.client.post(
-            "/api/v1/auth/refresh/",
-            format="json",
-        )
+        self._set_csrf_header()
+        res = self.api_client.post("/api/v1/auth/refresh/", format="json")
 
         self.assertEqual(res.status_code, 200)
-
-        data = res.json()
-        self.assertIn("access_token", data)
-        self.assertTrue(data["access_token"])
-        self.assertEqual(data["token_type"], "Bearer")
-        self.assertEqual(
-            data["expires_in"],
-            int(
-                cast(
-                    timedelta,
-                    settings.SIMPLE_JWT["ACCESS_TOKEN_LIFETIME"],
-                ).total_seconds()
-            ),
-        )
+        self.assertEqual(res.json()["message"], "액세스 토큰이 갱신되었습니다.")
+        self.assertIn("access_token", res.cookies)
+        self.assertIn("csrftoken", res.cookies)
+        self.assertTrue(res.cookies["access_token"].value)
+        self.assertNotEqual(res.cookies["access_token"].value, old_access_token)
 
     def test_refresh_without_refresh_token(self) -> None:
-        res = self.client.post(
-            "/api/v1/auth/refresh/",
-            format="json",
-        )
+        self._set_csrf_header()
+        res = self.api_client.post("/api/v1/auth/refresh/", format="json")
 
         self.assertEqual(res.status_code, 400)
-        data = res.json()
-        self.assertEqual(data["code"], "REFRESH_TOKEN_MISSING")
+        self.assertEqual(res.json()["code"], "REFRESH_TOKEN_MISSING")
 
     def test_refresh_with_invalid_refresh_token(self) -> None:
-        self.client.cookies["refresh_token"] = "invalid.token.value"
+        self._set_csrf_header()
+        self.api_client.cookies["refresh_token"] = "invalid.token.value"
 
-        res = self.client.post(
-            "/api/v1/auth/refresh/",
-            format="json",
-        )
+        res = self.api_client.post("/api/v1/auth/refresh/", format="json")
 
         self.assertEqual(res.status_code, 401)
-        data = res.json()
-        self.assertEqual(data["code"], "INVALID_REFRESH_TOKEN")
+        self.assertEqual(res.json()["code"], "INVALID_REFRESH_TOKEN")
 
     def test_refresh_with_deactivated_user(self) -> None:
-        login_res = self.client.post(
+        login_res = self.api_client.post(
             "/api/v1/auth/login/",
             {"email": "admin@example.com", "password": "password1100110011"},
             format="json",
@@ -82,11 +69,23 @@ class RefreshAPITestCase(TestCase):
         self.user.is_active = False
         self.user.save(update_fields=["is_active"])
 
-        res = self.client.post(
-            "/api/v1/auth/refresh/",
-            format="json",
-        )
+        self._set_csrf_header()
+        res = self.api_client.post("/api/v1/auth/refresh/", format="json")
 
         self.assertEqual(res.status_code, 401)
-        data = res.json()
-        self.assertEqual(data["code"], "ACCOUNT_DEACTIVATED")
+        self.assertEqual(res.json()["code"], "ACCOUNT_DEACTIVATED")
+
+    def test_refresh_ignores_invalid_access_token_cookie(self) -> None:
+        login_res = self.api_client.post(
+            "/api/v1/auth/login/",
+            {"email": "admin@example.com", "password": "password1100110011"},
+            format="json",
+        )
+        self.assertEqual(login_res.status_code, 200)
+
+        self.api_client.cookies["access_token"] = "invalid.token.value"
+        self._set_csrf_header()
+        res = self.api_client.post("/api/v1/auth/refresh/", format="json")
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json()["message"], "액세스 토큰이 갱신되었습니다.")

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -7,6 +7,7 @@ from apps.users.views.adult_verification import (
 )
 from apps.users.views.auth import (
     AccountRestoreAPIView,
+    AuthCSRFAPIView,
     AuthMeAPIView,
     EmailCodeSendAPIView,
     LoginAPIView,
@@ -32,6 +33,7 @@ from apps.users.views.social_auth import (
 urlpatterns = [
     path("auth/signup/", SignupAPIView.as_view(), name="auth-signup"),
     path("auth/email/code/", EmailCodeSendAPIView.as_view(), name="auth-email-code"),
+    path("auth/csrf/", AuthCSRFAPIView.as_view(), name="auth-csrf"),
     path("auth/login/", LoginAPIView.as_view(), name="auth-login"),
     path("auth/logout/", LogoutAPIView.as_view(), name="auth-logout"),
     path("auth/restore/", AccountRestoreAPIView.as_view(), name="auth-restore"),

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -1,18 +1,20 @@
-from datetime import timedelta
-from typing import Literal, TypedDict, cast
+from typing import cast
 
-from django.conf import settings
-from django.middleware.csrf import get_token
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
-from rest_framework.authentication import BaseAuthentication, CSRFCheck
+from rest_framework.authentication import BaseAuthentication
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.core.exceptions.exception_handler import CustomAPIException
-from apps.core.exceptions.exception_message import ErrorMessages
+from apps.core.auth_utils import (
+    enforce_csrf,
+    expire_auth_cookies,
+    set_access_token_cookie,
+    set_csrf_cookie,
+    set_refresh_token_cookie,
+)
 from apps.core.serializers.error_serializer import ErrorResponseSerializer
 from apps.users.models.user import User
 from apps.users.serializers.auth import (
@@ -38,57 +40,6 @@ from apps.users.services import (
     send_email_code,
     signup_user,
 )
-
-
-class _AuthCookieOptions(TypedDict):
-    httponly: bool
-    samesite: Literal["None"]
-    secure: bool
-
-
-class _CSRFCookieOptions(TypedDict):
-    samesite: Literal["None"]
-    secure: bool
-
-
-_AUTH_COOKIE_OPTIONS: _AuthCookieOptions = {
-    "httponly": True,
-    "samesite": "None",
-    "secure": True,
-}
-
-_CSRF_COOKIE_OPTIONS: _CSRFCookieOptions = {
-    "samesite": "None",
-    "secure": True,
-}
-
-
-def _enforce_csrf(request: Request) -> None:
-    check = CSRFCheck(request)  # type: ignore[arg-type]
-    check.process_request(request)
-    reason = check.process_view(request, lambda r: None, (), {})  # type: ignore[arg-type, return-value]
-    if reason:
-        raise CustomAPIException(ErrorMessages.CSRF_FAILED)
-
-
-def _set_access_token_cookie(*, response: Response, access_token: str, expires_in: int) -> None:
-    response.set_cookie("access_token", value=access_token, max_age=expires_in, **_AUTH_COOKIE_OPTIONS)
-
-
-def _set_refresh_token_cookie(*, response: Response, refresh_token: str) -> None:
-    refresh_max_age = int(cast(timedelta, settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"]).total_seconds())
-    response.set_cookie("refresh_token", value=refresh_token, max_age=refresh_max_age, **_AUTH_COOKIE_OPTIONS)
-
-
-def _set_csrf_cookie(*, request: Request, response: Response) -> str:
-    csrf_token = get_token(request)
-    response.set_cookie("csrftoken", value=csrf_token, **_CSRF_COOKIE_OPTIONS)
-    return csrf_token
-
-
-def _expire_auth_cookies(*, response: Response) -> None:
-    response.set_cookie("refresh_token", value="", max_age=0, **_AUTH_COOKIE_OPTIONS)
-    response.set_cookie("access_token", value="", max_age=0, **_AUTH_COOKIE_OPTIONS)
 
 
 @extend_schema(
@@ -158,7 +109,7 @@ class AuthCSRFAPIView(APIView):
 
     def get(self, request: Request) -> Response:
         response = Response(status=status.HTTP_200_OK)
-        csrf_token = _set_csrf_cookie(request=request, response=response)
+        csrf_token = set_csrf_cookie(request=request, response=response)
         response.data = CSRFTokenResponseSerializer({"csrf_token": csrf_token}).data
         return response
 
@@ -175,6 +126,7 @@ class AuthCSRFAPIView(APIView):
             response=ErrorResponseSerializer,
             description="INVALID_CREDENTIALS, ACCOUNT_DEACTIVATED",
         ),
+        403: OpenApiResponse(response=ErrorResponseSerializer, description="CSRF_FAILED"),
     },
     tags=["auth"],
 )
@@ -182,6 +134,8 @@ class LoginAPIView(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request: Request) -> Response:
+        enforce_csrf(request)
+
         serializer = LoginRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
@@ -190,9 +144,9 @@ class LoginAPIView(APIView):
 
         response_serializer = MessageResponseSerializer({"message": "로그인 되었습니다."})
         response = Response(response_serializer.data, status=status.HTTP_200_OK)
-        _set_access_token_cookie(response=response, access_token=access_token, expires_in=expires_in)
-        _set_refresh_token_cookie(response=response, refresh_token=refresh_token)
-        _set_csrf_cookie(request=request, response=response)
+        set_access_token_cookie(response=response, access_token=access_token, expires_in=expires_in)
+        set_refresh_token_cookie(response=response, refresh_token=refresh_token)
+        set_csrf_cookie(request=request, response=response)
         return response
 
 
@@ -212,12 +166,12 @@ class LogoutAPIView(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request: Request) -> Response:
-        _enforce_csrf(request)
+        enforce_csrf(request)
         logout_user(request.COOKIES.get("refresh_token"))
 
         response_serializer = MessageResponseSerializer({"message": "로그아웃 되었습니다."})
         response = Response(response_serializer.data, status=status.HTTP_200_OK)
-        _expire_auth_cookies(response=response)
+        expire_auth_cookies(response=response)
         return response
 
 
@@ -227,7 +181,7 @@ class LogoutAPIView(APIView):
     responses={
         200: OpenApiResponse(
             response=MessageResponseSerializer,
-            description="Refreshes the session, updates the HttpOnly access_token cookie, and reissues the csrftoken cookie.",
+            description="Refreshes the session, rotates the refresh token, updates the HttpOnly access_token and refresh_token cookies, and reissues the csrftoken cookie.",
         ),
         400: OpenApiResponse(response=ErrorResponseSerializer, description="REFRESH_TOKEN_MISSING"),
         401: OpenApiResponse(
@@ -243,13 +197,14 @@ class RefreshAPIView(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request: Request) -> Response:
-        _enforce_csrf(request)
-        access_token, expires_in = refresh_access_token(request.COOKIES.get("refresh_token"))
+        enforce_csrf(request)
+        access_token, refresh_token, expires_in = refresh_access_token(request.COOKIES.get("refresh_token"))
 
         response_serializer = MessageResponseSerializer({"message": "액세스 토큰이 갱신되었습니다."})
         response = Response(response_serializer.data, status=status.HTTP_200_OK)
-        _set_access_token_cookie(response=response, access_token=access_token, expires_in=expires_in)
-        _set_csrf_cookie(request=request, response=response)
+        set_access_token_cookie(response=response, access_token=access_token, expires_in=expires_in)
+        set_refresh_token_cookie(response=response, refresh_token=refresh_token)
+        set_csrf_cookie(request=request, response=response)
         return response
 
 

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -170,8 +170,7 @@ class AuthCSRFAPIView(APIView):
         200: OpenApiResponse(
             response=MessageResponseSerializer,
             description="Sets HttpOnly access_token and refresh_token cookies, and also issues a csrftoken cookie for subsequent unsafe requests.",
-        )
-        ,
+        ),
         401: OpenApiResponse(
             response=ErrorResponseSerializer,
             description="INVALID_CREDENTIALS, ACCOUNT_DEACTIVATED",

--- a/apps/users/views/auth.py
+++ b/apps/users/views/auth.py
@@ -1,17 +1,24 @@
-from typing import cast
+from datetime import timedelta
+from typing import Literal, TypedDict, cast
 
+from django.conf import settings
+from django.middleware.csrf import get_token
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
+from rest_framework.authentication import BaseAuthentication, CSRFCheck
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.core.exceptions.exception_handler import CustomAPIException
+from apps.core.exceptions.exception_message import ErrorMessages
 from apps.core.serializers.error_serializer import ErrorResponseSerializer
 from apps.users.models.user import User
 from apps.users.serializers.auth import (
     AccountRestoreRequestSerializer,
     AuthMeResponseSerializer,
+    CSRFTokenResponseSerializer,
     EmailCodeSendRequestSerializer,
     EmailCodeSendResponseSerializer,
     LoginRequestSerializer,
@@ -19,7 +26,6 @@ from apps.users.serializers.auth import (
     PasswordResetRequestSerializer,
     SignupRequestSerializer,
     SignupResponseSerializer,
-    TokenResponseSerializer,
 )
 from apps.users.services import (
     authenticate_user,
@@ -32,6 +38,57 @@ from apps.users.services import (
     send_email_code,
     signup_user,
 )
+
+
+class _AuthCookieOptions(TypedDict):
+    httponly: bool
+    samesite: Literal["None"]
+    secure: bool
+
+
+class _CSRFCookieOptions(TypedDict):
+    samesite: Literal["None"]
+    secure: bool
+
+
+_AUTH_COOKIE_OPTIONS: _AuthCookieOptions = {
+    "httponly": True,
+    "samesite": "None",
+    "secure": True,
+}
+
+_CSRF_COOKIE_OPTIONS: _CSRFCookieOptions = {
+    "samesite": "None",
+    "secure": True,
+}
+
+
+def _enforce_csrf(request: Request) -> None:
+    check = CSRFCheck(request)  # type: ignore[arg-type]
+    check.process_request(request)
+    reason = check.process_view(request, lambda r: None, (), {})  # type: ignore[arg-type, return-value]
+    if reason:
+        raise CustomAPIException(ErrorMessages.CSRF_FAILED)
+
+
+def _set_access_token_cookie(*, response: Response, access_token: str, expires_in: int) -> None:
+    response.set_cookie("access_token", value=access_token, max_age=expires_in, **_AUTH_COOKIE_OPTIONS)
+
+
+def _set_refresh_token_cookie(*, response: Response, refresh_token: str) -> None:
+    refresh_max_age = int(cast(timedelta, settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"]).total_seconds())
+    response.set_cookie("refresh_token", value=refresh_token, max_age=refresh_max_age, **_AUTH_COOKIE_OPTIONS)
+
+
+def _set_csrf_cookie(*, request: Request, response: Response) -> str:
+    csrf_token = get_token(request)
+    response.set_cookie("csrftoken", value=csrf_token, **_CSRF_COOKIE_OPTIONS)
+    return csrf_token
+
+
+def _expire_auth_cookies(*, response: Response) -> None:
+    response.set_cookie("refresh_token", value="", max_age=0, **_AUTH_COOKIE_OPTIONS)
+    response.set_cookie("access_token", value="", max_age=0, **_AUTH_COOKIE_OPTIONS)
 
 
 @extend_schema(
@@ -90,9 +147,36 @@ class EmailCodeSendAPIView(APIView):
 
 
 @extend_schema(
+    summary="CSRF 토큰 발급",
+    request=None,
+    responses={200: CSRFTokenResponseSerializer},
+    tags=["auth"],
+)
+class AuthCSRFAPIView(APIView):
+    authentication_classes: tuple[type[BaseAuthentication], ...] = ()
+    permission_classes = [AllowAny]
+
+    def get(self, request: Request) -> Response:
+        response = Response(status=status.HTTP_200_OK)
+        csrf_token = _set_csrf_cookie(request=request, response=response)
+        response.data = CSRFTokenResponseSerializer({"csrf_token": csrf_token}).data
+        return response
+
+
+@extend_schema(
     summary="로그인",
     request=LoginRequestSerializer,
-    responses={200: TokenResponseSerializer},
+    responses={
+        200: OpenApiResponse(
+            response=MessageResponseSerializer,
+            description="Sets HttpOnly access_token and refresh_token cookies, and also issues a csrftoken cookie for subsequent unsafe requests.",
+        )
+        ,
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="INVALID_CREDENTIALS, ACCOUNT_DEACTIVATED",
+        ),
+    },
     tags=["auth"],
 )
 class LoginAPIView(APIView):
@@ -105,21 +189,11 @@ class LoginAPIView(APIView):
         user = authenticate_user(**serializer.validated_data)
         access_token, refresh_token, expires_in = issue_auth_tokens(user)
 
-        response_serializer = TokenResponseSerializer(
-            {
-                "access_token": access_token,
-                "token_type": "Bearer",
-                "expires_in": expires_in,
-            }
-        )
+        response_serializer = MessageResponseSerializer({"message": "로그인 되었습니다."})
         response = Response(response_serializer.data, status=status.HTTP_200_OK)
-        response.set_cookie(
-            key="refresh_token",
-            value=refresh_token,
-            httponly=True,
-            samesite="None",
-            secure=True,
-        )
+        _set_access_token_cookie(response=response, access_token=access_token, expires_in=expires_in)
+        _set_refresh_token_cookie(response=response, refresh_token=refresh_token)
+        _set_csrf_cookie(request=request, response=response)
         return response
 
 
@@ -128,49 +202,56 @@ class LoginAPIView(APIView):
     request=None,
     responses={
         200: MessageResponseSerializer,
-        400: OpenApiResponse(
-            response=ErrorResponseSerializer,
-            description="INVALID_CODE, VALIDATION_ERROR, SOCIAL_USER_ONLY",
-        ),
-        429: OpenApiResponse(
-            response=ErrorResponseSerializer,
-            description="TOO_MANY_REQUESTS",
-        ),
+        400: OpenApiResponse(response=ErrorResponseSerializer, description="REFRESH_TOKEN_MISSING"),
+        401: OpenApiResponse(response=ErrorResponseSerializer, description="INVALID_REFRESH_TOKEN"),
+        403: OpenApiResponse(response=ErrorResponseSerializer, description="CSRF_FAILED"),
     },
     tags=["auth"],
 )
 class LogoutAPIView(APIView):
-    permission_classes = [IsAuthenticated]
+    authentication_classes: tuple[type[BaseAuthentication], ...] = ()
+    permission_classes = [AllowAny]
 
     def post(self, request: Request) -> Response:
+        _enforce_csrf(request)
         logout_user(request.COOKIES.get("refresh_token"))
 
         response_serializer = MessageResponseSerializer({"message": "로그아웃 되었습니다."})
         response = Response(response_serializer.data, status=status.HTTP_200_OK)
-        response.set_cookie("refresh_token", value="", samesite="None", secure=True, httponly=True, max_age=0)
-        response.set_cookie("access_token", value="", samesite="None", secure=True, httponly=True, max_age=0)
+        _expire_auth_cookies(response=response)
         return response
 
 
 @extend_schema(
     summary="액세스 토큰 재발급",
     request=None,
-    responses={200: TokenResponseSerializer},
+    responses={
+        200: OpenApiResponse(
+            response=MessageResponseSerializer,
+            description="Refreshes the session, updates the HttpOnly access_token cookie, and reissues the csrftoken cookie.",
+        ),
+        400: OpenApiResponse(response=ErrorResponseSerializer, description="REFRESH_TOKEN_MISSING"),
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="INVALID_REFRESH_TOKEN, REFRESH_TOKEN_EXPIRED, ACCOUNT_DEACTIVATED",
+        ),
+        403: OpenApiResponse(response=ErrorResponseSerializer, description="CSRF_FAILED"),
+    },
     tags=["auth"],
 )
 class RefreshAPIView(APIView):
+    authentication_classes: tuple[type[BaseAuthentication], ...] = ()
     permission_classes = [AllowAny]
 
     def post(self, request: Request) -> Response:
+        _enforce_csrf(request)
         access_token, expires_in = refresh_access_token(request.COOKIES.get("refresh_token"))
-        response_serializer = TokenResponseSerializer(
-            {
-                "access_token": access_token,
-                "token_type": "Bearer",
-                "expires_in": expires_in,
-            }
-        )
-        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+        response_serializer = MessageResponseSerializer({"message": "액세스 토큰이 갱신되었습니다."})
+        response = Response(response_serializer.data, status=status.HTTP_200_OK)
+        _set_access_token_cookie(response=response, access_token=access_token, expires_in=expires_in)
+        _set_csrf_cookie(request=request, response=response)
+        return response
 
 
 @extend_schema(
@@ -212,7 +293,13 @@ class AccountRestoreAPIView(APIView):
 @extend_schema(
     summary="현재 인증 사용자 조회",
     request=None,
-    responses={200: AuthMeResponseSerializer},
+    responses={
+        200: AuthMeResponseSerializer,
+        401: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="UNAUTHORIZED, TOKEN_EXPIRED, ACCOUNT_DEACTIVATED",
+        ),
+    },
     tags=["auth"],
 )
 class AuthMeAPIView(APIView):

--- a/apps/users/views/social_auth.py
+++ b/apps/users/views/social_auth.py
@@ -1,16 +1,14 @@
 import logging
-from datetime import timedelta
-from typing import Literal, TypedDict, cast
+from typing import cast
 
-from django.conf import settings
 from django.http import HttpResponseRedirect
-from django.middleware.csrf import get_token
 from django.shortcuts import redirect
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.views import APIView
 
+from apps.core.auth_utils import set_access_token_cookie, set_csrf_cookie, set_refresh_token_cookie
 from apps.core.exceptions.exception_handler import CustomAPIException
 from apps.users.services import (
     build_discord_login_url,
@@ -24,32 +22,9 @@ from apps.users.services import (
 logger = logging.getLogger(__name__)
 
 
-class _CookieOptions(TypedDict):
-    httponly: bool
-    samesite: Literal["None"]
-    secure: bool
-
-
-class _CSRFCookieOptions(TypedDict):
-    samesite: Literal["None"]
-    secure: bool
-
-
-_COOKIE_OPTIONS: _CookieOptions = {
-    "httponly": True,
-    "samesite": "None",
-    "secure": True,
-}
-
-_CSRF_COOKIE_OPTIONS: _CSRFCookieOptions = {
-    "samesite": "None",
-    "secure": True,
-}
-
-
 @extend_schema(
     summary="카카오 로그인",
-    description="카카오 OAuth 인증 페이지로 리다이렉트합니다. CSRF 방지용 state 값을 생성하여 캐시에 저장합니다.",
+    description="카카오 OAuth 인증 페이지로 리다이렉트합니다. CSRF 방어용 state 값을 생성하여 캐시에 저장합니다.",
     request=None,
     responses={
         302: OpenApiResponse(description="카카오 OAuth 인증 페이지로 리다이렉트"),
@@ -76,25 +51,14 @@ class SocialCallbackAPIView(APIView):
 
         try:
             result = self.handle_callback(code=code, state=state)
-            refresh_max_age = int(cast(timedelta, settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"]).total_seconds())
             response = redirect(build_social_success_redirect_url(is_new_user=bool(result["is_new_user"])))
-            response.set_cookie(
-                key="access_token",
-                value=str(result["access_token"]),
-                max_age=cast(int, result["expires_in"]),
-                **_COOKIE_OPTIONS,
+            set_access_token_cookie(
+                response=response,
+                access_token=str(result["access_token"]),
+                expires_in=cast(int, result["expires_in"]),
             )
-            response.set_cookie(
-                key="refresh_token",
-                value=str(result["refresh_token"]),
-                max_age=refresh_max_age,
-                **_COOKIE_OPTIONS,
-            )
-            response.set_cookie(
-                key="csrftoken",
-                value=get_token(request),
-                **_CSRF_COOKIE_OPTIONS,
-            )
+            set_refresh_token_cookie(response=response, refresh_token=str(result["refresh_token"]))
+            set_csrf_cookie(request=request, response=response)
             return response
 
         except CustomAPIException as e:
@@ -138,7 +102,7 @@ class SocialCallbackAPIView(APIView):
             type=str,
             location=OpenApiParameter.QUERY,
             required=True,
-            description="CSRF 방지용 state 값 (로그인 요청 시 발급)",
+            description="CSRF 방어용 state 값(로그인 요청 시 발급)",
         ),
     ],
     responses={
@@ -158,7 +122,7 @@ class KakaoCallbackAPIView(SocialCallbackAPIView):
 
 @extend_schema(
     summary="디스코드 로그인",
-    description="디스코드 OAuth 인증 페이지로 리다이렉트합니다. CSRF 방지용 state 값을 생성하여 캐시에 저장합니다.",
+    description="디스코드 OAuth 인증 페이지로 리다이렉트합니다. CSRF 방어용 state 값을 생성하여 캐시에 저장합니다.",
     request=None,
     responses={
         302: OpenApiResponse(description="디스코드 OAuth 인증 페이지로 리다이렉트"),
@@ -195,7 +159,7 @@ class DiscordLoginAPIView(APIView):
             type=str,
             location=OpenApiParameter.QUERY,
             required=True,
-            description="CSRF 방지용 state 값 (로그인 요청 시 발급)",
+            description="CSRF 방어용 state 값(로그인 요청 시 발급)",
         ),
     ],
     responses={

--- a/apps/users/views/social_auth.py
+++ b/apps/users/views/social_auth.py
@@ -4,6 +4,7 @@ from typing import Literal, TypedDict, cast
 
 from django.conf import settings
 from django.http import HttpResponseRedirect
+from django.middleware.csrf import get_token
 from django.shortcuts import redirect
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework.permissions import AllowAny
@@ -29,8 +30,18 @@ class _CookieOptions(TypedDict):
     secure: bool
 
 
+class _CSRFCookieOptions(TypedDict):
+    samesite: Literal["None"]
+    secure: bool
+
+
 _COOKIE_OPTIONS: _CookieOptions = {
     "httponly": True,
+    "samesite": "None",
+    "secure": True,
+}
+
+_CSRF_COOKIE_OPTIONS: _CSRFCookieOptions = {
     "samesite": "None",
     "secure": True,
 }
@@ -79,6 +90,11 @@ class SocialCallbackAPIView(APIView):
                 max_age=refresh_max_age,
                 **_COOKIE_OPTIONS,
             )
+            response.set_cookie(
+                key="csrftoken",
+                value=get_token(request),
+                **_CSRF_COOKIE_OPTIONS,
+            )
             return response
 
         except CustomAPIException as e:
@@ -105,7 +121,7 @@ class SocialCallbackAPIView(APIView):
     description=(
         "카카오 OAuth 인증 후 호출되는 콜백 엔드포인트입니다.\n\n"
         "**성공 시** `{FRONTEND_DOMAIN}/auth/callback?is_new_user=true|false` 로 리다이렉트하며, "
-        "`access_token`과 `refresh_token`을 HttpOnly 쿠키로 설정합니다.\n\n"
+        "`access_token`과 `refresh_token`을 HttpOnly 쿠키로 설정하고, `csrftoken` 쿠키를 함께 발급합니다.\n\n"
         "**실패 시** `{FRONTEND_DOMAIN}/auth/callback?error={코드}&error_description={메시지}` 로 리다이렉트합니다."
     ),
     request=None,
@@ -128,7 +144,7 @@ class SocialCallbackAPIView(APIView):
     responses={
         302: OpenApiResponse(
             description=(
-                "성공: ?is_new_user=true|false + Set-Cookie: access_token, refresh_token (HttpOnly)\n"
+                "성공: ?is_new_user=true|false + Set-Cookie: access_token, refresh_token (HttpOnly), csrftoken\n"
                 "실패: ?error={에러코드}&error_description={메시지}"
             )
         ),
@@ -162,7 +178,7 @@ class DiscordLoginAPIView(APIView):
     description=(
         "디스코드 OAuth 인증 후 호출되는 콜백 엔드포인트입니다.\n\n"
         "**성공 시** `{FRONTEND_DOMAIN}/auth/callback?is_new_user=true|false` 로 리다이렉트하며, "
-        "`access_token`과 `refresh_token`을 HttpOnly 쿠키로 설정합니다.\n\n"
+        "`access_token`과 `refresh_token`을 HttpOnly 쿠키로 설정하고, `csrftoken` 쿠키를 함께 발급합니다.\n\n"
         "**실패 시** `{FRONTEND_DOMAIN}/auth/callback?error={코드}&error_description={메시지}` 로 리다이렉트합니다."
     ),
     request=None,
@@ -185,7 +201,7 @@ class DiscordLoginAPIView(APIView):
     responses={
         302: OpenApiResponse(
             description=(
-                "성공: ?is_new_user=true|false + Set-Cookie: access_token, refresh_token (HttpOnly)\n"
+                "성공: ?is_new_user=true|false + Set-Cookie: access_token, refresh_token (HttpOnly), csrftoken\n"
                 "실패: ?error={에러코드}&error_description={메시지}"
             )
         ),


### PR DESCRIPTION
## ✅ PR 요약
- 일반 로그인과 소셜 로그인의 인증 방식을 쿠키 기반으로 통일했습니다.

## 📄 상세 내용
- [x] 일반 로그인도 `access_token`, `refresh_token`을 모두 HttpOnly 쿠키로 발급하도록 변경했습니다.
- [x] `GET /api/v1/auth/csrf/` 엔드포인트를 추가해 `csrftoken` 쿠키와 응답 바디 토큰을 함께 발급하도록 했습니다.
- [x] `POST /api/v1/auth/refresh/`가 `refresh_token` 쿠키 기준으로 동작하며, 새 `access_token` 쿠키와 `csrftoken` 쿠키를 재발급하도록 변경했습니다.
- [x] `POST /api/v1/auth/logout/`이 쿠키 기반 세션 종료 흐름으로 동작하도록 정리했습니다.
- [x] `GET /api/v1/auth/me/`를 실제 쿠키 인증 경로 기준으로 검증하도록 테스트를 보강했습니다.
- [x] 카카오/디스코드 소셜 로그인 callback 성공 시 `csrftoken` 쿠키도 함께 발급하도록 변경했습니다.
- [x] 로그인 / refresh / logout / auth-me / 소셜 callback 관련 Swagger 문서를 현재 동작에 맞게 보강했습니다.