### PR TITLE
 [Feature/users/me-social-info] users/me 응답에 소셜 유저 정보 추가

### DIFF
--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -4,6 +4,9 @@ from apps.users.models.user import User
 
 
 class UserMeResponseSerializer(serializers.ModelSerializer[User]):
+    is_social_user = serializers.SerializerMethodField()
+    social_provider = serializers.SerializerMethodField()
+
     class Meta:
         model = User
         fields = [
@@ -15,8 +18,17 @@ class UserMeResponseSerializer(serializers.ModelSerializer[User]):
             "is_adult_verified",
             "adult_verified_at",
             "is_active",
+            "is_social_user",
+            "social_provider",
             "created_at",
         ]
+
+    def get_is_social_user(self, obj: User) -> bool:
+        return obj.social_accounts.exists() and not obj.has_usable_password()
+
+    def get_social_provider(self, obj: User) -> str | None:
+        social_account = obj.social_accounts.order_by("id").first()
+        return social_account.provider if social_account is not None else None
 
 
 class UserMeUpdateResponseSerializer(serializers.ModelSerializer[User]):

--- a/apps/users/tests/test_user_me.py
+++ b/apps/users/tests/test_user_me.py
@@ -7,8 +7,8 @@ from rest_framework.response import Response
 from rest_framework.test import APIClient
 
 from apps.core.exceptions.exception_message import ErrorMessages
-from apps.users.models.social_user import SocialUser
 from apps.core.testcase import FastTestCase
+from apps.users.models.social_user import SocialUser
 from apps.users.tasks import purge_soft_deleted_users
 
 

--- a/apps/users/tests/test_user_me.py
+++ b/apps/users/tests/test_user_me.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework.test import APIClient
 
 from apps.core.exceptions.exception_message import ErrorMessages
+from apps.users.models.social_user import SocialUser
 from apps.core.testcase import FastTestCase
 from apps.users.tasks import purge_soft_deleted_users
 
@@ -39,7 +40,29 @@ class UserMeRetrieveAPITest(FastTestCase):
         self.assertEqual(drf_res.data["is_adult_verified"], self.user.is_adult_verified)
         self.assertEqual(drf_res.data["adult_verified_at"], self.user.adult_verified_at)
         self.assertEqual(drf_res.data["is_active"], self.user.is_active)
+        self.assertFalse(drf_res.data["is_social_user"])
+        self.assertIsNone(drf_res.data["social_provider"])
         self.assertTrue(drf_res.data["created_at"])
+
+    def test_get_me_returns_social_user_info_for_social_only_account(self) -> None:
+        self.user.set_unusable_password()
+        self.user.save(update_fields=["password"])
+        SocialUser.objects.create(
+            user=self.user,
+            provider=SocialUser.Provider.KAKAO,
+            provider_uid="kakao-social-only",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        res = client.get("/api/v1/users/me/")
+
+        drf_res = cast(Response, res)
+
+        self.assertEqual(drf_res.status_code, 200)
+        self.assertTrue(drf_res.data["is_social_user"])
+        self.assertEqual(drf_res.data["social_provider"], SocialUser.Provider.KAKAO)
 
     def test_get_me_returns_401_when_not_authenticated(self) -> None:
         noauth_res = self.client.get("/api/v1/users/me/")
@@ -116,8 +139,6 @@ class UserMeRetrieveAPITest(FastTestCase):
         self.assertEqual(res.json()["code"], ErrorMessages.VALIDATION_ERROR.name)
 
     def test_patch_me_returns_400_for_social_only_user_with_new_password(self) -> None:
-        from apps.users.models.social_user import SocialUser
-
         self.user.set_unusable_password()
         self.user.save(update_fields=["password"])
         SocialUser.objects.create(


### PR DESCRIPTION
## ✅ PR 요약
- `GET /api/v1/users/me/` 응답에 소셜 유저 여부 정보를 추가했습니다.

## 📄 상세 내용
- [x] `users/me` 응답에 `is_social_user` 필드를 추가했습니다.
- [x] `users/me` 응답에 `social_provider` 필드를 추가했습니다.
- [x] 소셜 전용 계정은 `social_accounts.exists() && !has_usable_password()` 기준으로 판별하도록 맞췄습니다.
- [x] 프론트가 내정보 수정 진입 시 비밀번호 변경 UI를 소셜 유저 기준으로 분기할 수 있도록 응답 정보를 보강했습니다.
- [x] 일반 유저/소셜 유저 각각의 응답 검증 테스트를 추가했습니다.

