### PR TITLE
refactor: test code 전면 수정

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,12 @@ seed:
 
 # 테스트 -------------------------------------------------------------------
 test:
-	$(DJANGO) coverage run manage.py test
+	$(DJANGO) coverage run manage.py test --keepdb
 	$(DJANGO) coverage report
 
 # 특정 앱만: make test-app APP=users
 test-app:
-	$(DJANGO) coverage run manage.py test apps.$(APP)
+	$(DJANGO) coverage run manage.py test apps.$(APP) --keepdb
 	$(DJANGO) coverage report
 
 # 코드 품질 ----------------------------------------------------------------

--- a/apps/games/tests/test_exception_handler.py
+++ b/apps/games/tests/test_exception_handler.py
@@ -1,7 +1,7 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase
 from rest_framework.exceptions import NotFound
 
 from apps.core.exceptions.exception_handler import CustomAPIException, custom_exception_handler
@@ -14,7 +14,7 @@ def _context() -> dict[str, MagicMock]:
     return {"view": MagicMock(), "request": MagicMock()}
 
 
-class CustomAPIExceptionTests(TestCase):
+class CustomAPIExceptionTests(SimpleTestCase):
     def test_creates_with_error_messages(self) -> None:
         exc = CustomAPIException(ErrorMessages.GAME_NOT_FOUND)
         self.assertEqual(exc.status_code, 404)
@@ -22,7 +22,7 @@ class CustomAPIExceptionTests(TestCase):
         self.assertIn("게임", exc.detail["message"])  # type: ignore[call-overload, index]
 
 
-class CustomExceptionHandlerTests(TestCase):
+class CustomExceptionHandlerTests(SimpleTestCase):
     def test_drf_exception_handled(self) -> None:
         exc = NotFound("not found")
         response = custom_exception_handler(exc, _context())

--- a/apps/games/tests/test_igdb_client.py
+++ b/apps/games/tests/test_igdb_client.py
@@ -1,7 +1,7 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, override_settings
 
 from apps.games.igdb.client import IgdbClient, get_igdb_client, get_image_url
 from apps.games.igdb.exceptions import (
@@ -12,7 +12,7 @@ from apps.games.igdb.exceptions import (
 )
 
 
-class GetImageUrlTests(TestCase):
+class GetImageUrlTests(SimpleTestCase):
     def test_default_size(self) -> None:
         url = get_image_url("co1234")
         self.assertEqual(url, "https://images.igdb.com/igdb/image/upload/t_cover_big/co1234.jpg")
@@ -23,7 +23,7 @@ class GetImageUrlTests(TestCase):
 
 
 @override_settings(IGDB_CLIENT_ID="test_id", IGDB_CLIENT_SECRET="test_secret")
-class IgdbClientTests(TestCase):
+class IgdbClientTests(SimpleTestCase):
     def _make_client(self, mock_session: Any) -> tuple[IgdbClient, MagicMock]:
         """Create an IgdbClient with mocked session and token fetch."""
         token_resp = MagicMock()
@@ -354,7 +354,7 @@ class IgdbClientTests(TestCase):
 
 
 @override_settings(IGDB_CLIENT_ID="test_id", IGDB_CLIENT_SECRET="test_secret")
-class GetIgdbClientTests(TestCase):
+class GetIgdbClientTests(SimpleTestCase):
     @patch("apps.games.igdb.client._build_session")
     def test_singleton(self, mock_build: MagicMock) -> None:
         session = MagicMock()

--- a/apps/games/tests/test_igdb_converters.py
+++ b/apps/games/tests/test_igdb_converters.py
@@ -2,7 +2,7 @@ from datetime import date
 from decimal import Decimal
 from typing import Any
 
-from django.test import TestCase
+from django.test import SimpleTestCase
 
 from apps.games.igdb.converters import (
     _parse_cover_url,
@@ -23,7 +23,7 @@ from apps.games.igdb.converters import (
 )
 
 
-class TimestampToDateTests(TestCase):
+class TimestampToDateTests(SimpleTestCase):
     def test_valid_timestamp(self) -> None:
         # 2020-01-01 00:00:00 UTC
         self.assertEqual(_timestamp_to_date(1577836800), date(2020, 1, 1))
@@ -38,7 +38,7 @@ class TimestampToDateTests(TestCase):
         self.assertIsNone(_timestamp_to_date(99999999999999))
 
 
-class ParseEsrbTests(TestCase):
+class ParseEsrbTests(SimpleTestCase):
     def test_none_returns_unknown(self) -> None:
         self.assertEqual(_parse_esrb(None), ("unknown", 0))
 
@@ -93,7 +93,7 @@ class ParseEsrbTests(TestCase):
         self.assertEqual(_parse_esrb(ratings), ("teen", 13))
 
 
-class ParseRatingTests(TestCase):
+class ParseRatingTests(SimpleTestCase):
     def test_none_returns_zero(self) -> None:
         self.assertEqual(_parse_rating(None), Decimal("0.00"))
 
@@ -114,7 +114,7 @@ class ParseRatingTests(TestCase):
         self.assertEqual(result, Decimal("75.5") / Decimal("20"))
 
 
-class ParseCoverUrlTests(TestCase):
+class ParseCoverUrlTests(SimpleTestCase):
     def test_valid_cover(self) -> None:
         cover = {"image_id": "co1234"}
         result = _parse_cover_url(cover)
@@ -134,7 +134,7 @@ class ParseCoverUrlTests(TestCase):
         self.assertEqual(_parse_cover_url({"image_id": ""}), "")
 
 
-class ParseWebsiteTests(TestCase):
+class ParseWebsiteTests(SimpleTestCase):
     def test_official_website(self) -> None:
         websites = [{"category": 1, "url": "https://example.com"}]
         self.assertEqual(_parse_website(websites), "https://example.com")
@@ -158,7 +158,7 @@ class ParseWebsiteTests(TestCase):
         self.assertEqual(_parse_website(websites), "")
 
 
-class ConvertGenreTests(TestCase):
+class ConvertGenreTests(SimpleTestCase):
     def test_basic(self) -> None:
         raw = {"id": 5, "name": "Shooter", "slug": "shooter"}
         result = convert_genre(raw)
@@ -179,7 +179,7 @@ class ConvertGenreTests(TestCase):
         self.assertEqual(len(result["slug"]), 50)
 
 
-class ConvertPlatformTests(TestCase):
+class ConvertPlatformTests(SimpleTestCase):
     def test_basic(self) -> None:
         raw = {"id": 48, "name": "PlayStation 4", "slug": "ps4"}
         result = convert_platform(raw)
@@ -209,7 +209,7 @@ class ConvertPlatformTests(TestCase):
         self.assertIsNone(result["icon_url"])
 
 
-class ConvertTagTests(TestCase):
+class ConvertTagTests(SimpleTestCase):
     def test_basic(self) -> None:
         raw = {"id": 10, "name": "Action", "slug": "action"}
         result = convert_tag(raw)
@@ -218,7 +218,7 @@ class ConvertTagTests(TestCase):
         self.assertEqual(result["slug"], "action")
 
 
-class ConvertGameTests(TestCase):
+class ConvertGameTests(SimpleTestCase):
     def _make_raw(self, **overrides: Any) -> dict[str, Any]:
         base: dict[str, Any] = {
             "id": 1942,
@@ -283,7 +283,7 @@ class ConvertGameTests(TestCase):
         self.assertIsNone(result["rawg_updated"])
 
 
-class ExtractGenreIgdbIdsTests(TestCase):
+class ExtractGenreIgdbIdsTests(SimpleTestCase):
     def test_basic(self) -> None:
         raw = {"genres": [{"id": 1}, {"id": 2}]}
         self.assertEqual(extract_genre_igdb_ids(raw), [1, 2])
@@ -299,7 +299,7 @@ class ExtractGenreIgdbIdsTests(TestCase):
         self.assertEqual(extract_genre_igdb_ids(raw), [1])
 
 
-class ExtractKeywordIgdbIdsTests(TestCase):
+class ExtractKeywordIgdbIdsTests(SimpleTestCase):
     def test_basic(self) -> None:
         raw = {"keywords": [{"id": 10}, {"id": 20}]}
         self.assertEqual(extract_keyword_igdb_ids(raw), [10, 20])
@@ -312,7 +312,7 @@ class ExtractKeywordIgdbIdsTests(TestCase):
         self.assertEqual(extract_keyword_igdb_ids(raw), [10])
 
 
-class ExtractPlatformEntriesTests(TestCase):
+class ExtractPlatformEntriesTests(SimpleTestCase):
     def test_basic(self) -> None:
         raw = {"platforms": [{"id": 48}, {"id": 49}]}
         entries = extract_platform_entries(raw)
@@ -328,7 +328,7 @@ class ExtractPlatformEntriesTests(TestCase):
         self.assertEqual(len(extract_platform_entries(raw)), 1)
 
 
-class ExtractStoreEntriesTests(TestCase):
+class ExtractStoreEntriesTests(SimpleTestCase):
     def test_steam_url(self) -> None:
         raw = {"websites": [{"url": "https://store.steampowered.com/app/1234"}]}
         entries = extract_store_entries(raw)
@@ -374,7 +374,7 @@ class ExtractStoreEntriesTests(TestCase):
         self.assertEqual(slugs, {"steam", "gog"})
 
 
-class ConvertScreenshotTests(TestCase):
+class ConvertScreenshotTests(SimpleTestCase):
     def test_basic(self) -> None:
         raw = {"id": 100, "image_id": "sc_abc"}
         result = convert_screenshot(1942, raw)
@@ -392,7 +392,7 @@ class ConvertScreenshotTests(TestCase):
         self.assertEqual(result["media_url"], "")
 
 
-class ConvertTrailerTests(TestCase):
+class ConvertTrailerTests(SimpleTestCase):
     def test_basic(self) -> None:
         raw = {"id": 200, "video_id": "abc123", "name": "Trailer 1"}
         result = convert_trailer(1942, raw)

--- a/apps/games/tests/test_igdb_response_builder.py
+++ b/apps/games/tests/test_igdb_response_builder.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from typing import Any
 
-from django.test import TestCase
+from django.test import SimpleTestCase
 
 from apps.games.igdb.response_builder import (
     build_game_detail,
@@ -10,7 +10,7 @@ from apps.games.igdb.response_builder import (
 )
 
 
-class BuildGameListItemTests(TestCase):
+class BuildGameListItemTests(SimpleTestCase):
     def _make_raw(self, **overrides: Any) -> dict[str, Any]:
         base: dict[str, Any] = {
             "id": 1942,
@@ -75,7 +75,7 @@ class BuildGameListItemTests(TestCase):
         self.assertEqual(result["rawg_ratings_count"], 0)
 
 
-class BuildGameDetailTests(TestCase):
+class BuildGameDetailTests(SimpleTestCase):
     def _make_raw(self, **overrides: Any) -> dict[str, Any]:
         base: dict[str, Any] = {
             "id": 1942,
@@ -181,7 +181,7 @@ class BuildGameDetailTests(TestCase):
         self.assertEqual(result["description"], "")
 
 
-class BuildSimilarGameItemTests(TestCase):
+class BuildSimilarGameItemTests(SimpleTestCase):
     def _make_raw(self, **overrides: Any) -> dict[str, Any]:
         base: dict[str, Any] = {
             "id": 100,

--- a/apps/interactions/tests.py
+++ b/apps/interactions/tests.py
@@ -26,20 +26,8 @@ IGDB_GAME_ID_STORE = 8001
 class InteractionViewLogCreateAPITestCase(TestCase):
     client: APIClient
 
-    def setUp(self) -> None:
-        self.client = APIClient()
-        self.url = "/api/v1/interactions/view/"
-        self._create_view_rules()
-
-    def _create_user(self) -> User:
-        return User.objects.create_user(
-            email="user@ex.com",
-            nickname="user",
-            birth_date=date(1990, 1, 1),
-            password="pw",
-        )
-
-    def _create_view_rules(self) -> None:
+    @classmethod
+    def setUpTestData(cls) -> None:
         InteractionWeightRule.objects.create(
             interaction_type=InteractionWeightRule.ActionType.VIEW,
             base_weight=0.20,
@@ -68,6 +56,18 @@ class InteractionViewLogCreateAPITestCase(TestCase):
                     interaction_source=InteractionContextRule.InteractionSource.ONBOARDING, multiplier=1.50
                 ),
             ]
+        )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/interactions/view/"
+
+    def _create_user(self) -> User:
+        return User.objects.create_user(
+            email="user@ex.com",
+            nickname="user",
+            birth_date=date(1990, 1, 1),
+            password="pw",
         )
 
     def test_interaction_view_unauthorized(self) -> None:
@@ -250,20 +250,8 @@ class InteractionViewLogCreateAPITestCase(TestCase):
 class InteractionSearchLogCreateAPITestCase(TestCase):
     client: APIClient
 
-    def setUp(self) -> None:
-        self.client = APIClient()
-        self.url = "/api/v1/interactions/search/"
-        self._create_search_rules()
-
-    def _create_user(self) -> User:
-        return User.objects.create_user(
-            email="search-user@ex.com",
-            nickname="search-user",
-            birth_date=date(1992, 1, 1),
-            password="pw",
-        )
-
-    def _create_search_rules(self) -> None:
+    @classmethod
+    def setUpTestData(cls) -> None:
         InteractionWeightRule.objects.create(
             interaction_type=InteractionWeightRule.ActionType.SEARCH,
             base_weight=0.10,
@@ -274,6 +262,18 @@ class InteractionSearchLogCreateAPITestCase(TestCase):
         InteractionContextRule.objects.get_or_create(
             interaction_source=InteractionContextRule.InteractionSource.SEARCH_RESULT,
             defaults={"multiplier": 1.10},
+        )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/interactions/search/"
+
+    def _create_user(self) -> User:
+        return User.objects.create_user(
+            email="search-user@ex.com",
+            nickname="search-user",
+            birth_date=date(1992, 1, 1),
+            password="pw",
         )
 
     def test_interaction_search_unauthorized(self) -> None:
@@ -456,10 +456,23 @@ class InteractionSearchLogCreateAPITestCase(TestCase):
 class InteractionStoreClickLogCreateAPITestCase(TestCase):
     client: APIClient
 
+    @classmethod
+    def setUpTestData(cls) -> None:
+        InteractionWeightRule.objects.create(
+            interaction_type=InteractionWeightRule.ActionType.STORE_CLICK,
+            base_weight=0.10,
+            cooldown_seconds=120,
+            repeat_decay=0.900,
+            is_active=True,
+        )
+        InteractionContextRule.objects.get_or_create(
+            interaction_source=InteractionContextRule.InteractionSource.DETAIL_PAGE,
+            defaults={"multiplier": 1.20},
+        )
+
     def setUp(self) -> None:
         self.client = APIClient()
         self.url = "/api/v1/interactions/store-click/"
-        self._create_store_click_rules()
 
     def _create_user(self) -> User:
         return User.objects.create_user(
@@ -479,19 +492,6 @@ class InteractionStoreClickLogCreateAPITestCase(TestCase):
         }
         defaults.update(kwargs)
         return ExternalStore.objects.create(**defaults)
-
-    def _create_store_click_rules(self) -> None:
-        InteractionWeightRule.objects.create(
-            interaction_type=InteractionWeightRule.ActionType.STORE_CLICK,
-            base_weight=0.10,
-            cooldown_seconds=120,
-            repeat_decay=0.900,
-            is_active=True,
-        )
-        InteractionContextRule.objects.get_or_create(
-            interaction_source=InteractionContextRule.InteractionSource.DETAIL_PAGE,
-            defaults={"multiplier": 1.20},
-        )
 
     def test_interaction_store_click_unauthorized(self) -> None:
         response = self.client.post(
@@ -1030,28 +1030,37 @@ class AdminInteractionWeightRuleUpdateAPITestCase(TestCase):
 
 class AdminUserInteractionListAPITestCase(TestCase):
     client: APIClient
+    admin_user: User
+    target_user: User
+    normal_user: User
 
-    def setUp(self) -> None:
-        self.client = APIClient()
-        self.admin_user = User.objects.create_user(
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.admin_user = User.objects.create_user(
             email="admin-int@ex.com",
             nickname="admin-int",
             birth_date=date(1991, 1, 1),
             password="pw",
             is_staff=True,
         )
-        self.target_user = User.objects.create_user(
+        cls.target_user = User.objects.create_user(
             email="target-int@ex.com",
             nickname="target-int",
             birth_date=date(1992, 1, 1),
             password="pw",
         )
-        self.normal_user = User.objects.create_user(
+        cls.normal_user = User.objects.create_user(
             email="normal-int@ex.com",
             nickname="normal-int",
             birth_date=date(1993, 1, 1),
             password="pw",
         )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.admin_user.refresh_from_db()
+        self.target_user.refresh_from_db()
+        self.normal_user.refresh_from_db()
         self.base_url = f"/api/v1/admin/users/{self.target_user.id}/interactions/"
 
     def test_admin_user_interaction_list_unauthorized(self) -> None:

--- a/apps/preferences/tests.py
+++ b/apps/preferences/tests.py
@@ -22,17 +22,22 @@ class PreferenceBaseTestCase(TestCase):
     """공통 유저 생성 및 인증을 담당하는 베이스 클래스"""
 
     client: APIClient
+    user: User
 
-    def setUp(self) -> None:
-        self.client = APIClient()
-        self.client.raise_request_exception = True
-        self.user = User.objects.create_user(
-            email=f"test_{self.__class__.__name__}@example.com",
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = User.objects.create_user(
+            email=f"test_{cls.__name__}@example.com",
             nickname="tester",
             birth_date=date(1990, 1, 1),
             password="testpass123",
         )
-        UserPreference.objects.get_or_create(user=self.user)
+        UserPreference.objects.get_or_create(user=cls.user)
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.client.raise_request_exception = True
+        self.user.refresh_from_db()
         # 기본적으로 인증된 상태로 시작
         self.client.force_authenticate(user=self.user)
 

--- a/apps/recommendations/tests.py
+++ b/apps/recommendations/tests.py
@@ -159,16 +159,21 @@ class RecommendationListAPITestCase(TestCase):
 
 class RecommendationStatusAPITestCase(TestCase):
     client: APIClient
+    user: User
 
-    def setUp(self) -> None:
-        self.client = APIClient()
-        self.url = "/api/v1/recommendations/status/"
-        self.user = User.objects.create_user(
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = User.objects.create_user(
             email="status-user@ex.com",
             nickname="status-user",
             birth_date=date(1991, 1, 1),
             password="pw",
         )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/recommendations/status/"
+        self.user.refresh_from_db()
 
     def _create_recommendation(self, *, generation: int) -> UserRecommendation:
         igdb_game_id = 9000 + generation
@@ -454,23 +459,30 @@ class RecommendationTaskTestCase(TestCase):
 
 class AdminRecommendationJobListAPITestCase(TestCase):
     client: APIClient
+    admin_user: User
+    normal_user: User
 
-    def setUp(self) -> None:
-        self.client = APIClient()
-        self.url = "/api/v1/admin/recommendation-jobs/"
-        self.admin_user = User.objects.create_user(
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.admin_user = User.objects.create_user(
             email="admin-rec@ex.com",
             nickname="admin-rec",
             birth_date=date(1990, 1, 1),
             password="pw",
             is_staff=True,
         )
-        self.normal_user = User.objects.create_user(
+        cls.normal_user = User.objects.create_user(
             email="normal-rec@ex.com",
             nickname="normal-rec",
             birth_date=date(1994, 1, 1),
             password="pw",
         )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/admin/recommendation-jobs/"
+        self.admin_user.refresh_from_db()
+        self.normal_user.refresh_from_db()
 
     def test_admin_recommendation_job_list_unauthorized(self) -> None:
         response = self.client.get(self.url)
@@ -574,22 +586,29 @@ class AdminRecommendationJobListAPITestCase(TestCase):
 
 class AdminRecommendationJobDetailAPITestCase(TestCase):
     client: APIClient
+    admin_user: User
+    normal_user: User
 
-    def setUp(self) -> None:
-        self.client = APIClient()
-        self.admin_user = User.objects.create_user(
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.admin_user = User.objects.create_user(
             email="admin-detail@ex.com",
             nickname="admin-detail",
             birth_date=date(1990, 1, 1),
             password="pw",
             is_staff=True,
         )
-        self.normal_user = User.objects.create_user(
+        cls.normal_user = User.objects.create_user(
             email="normal-detail@ex.com",
             nickname="normal-detail",
             birth_date=date(1994, 1, 1),
             password="pw",
         )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.admin_user.refresh_from_db()
+        self.normal_user.refresh_from_db()
 
     def _url(self, job_id: int) -> str:
         return f"/api/v1/admin/recommendation-jobs/{job_id}/"
@@ -649,23 +668,30 @@ class AdminRecommendationJobDetailAPITestCase(TestCase):
 
 class AdminRecommendationJobRunAPITestCase(TestCase):
     client: APIClient
+    admin_user: User
+    normal_user: User
 
-    def setUp(self) -> None:
-        self.client = APIClient()
-        self.url = "/api/v1/admin/recommendation-jobs/run/"
-        self.admin_user = User.objects.create_user(
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.admin_user = User.objects.create_user(
             email="admin-run@ex.com",
             nickname="admin-run",
             birth_date=date(1990, 1, 1),
             password="pw",
             is_staff=True,
         )
-        self.normal_user = User.objects.create_user(
+        cls.normal_user = User.objects.create_user(
             email="normal-run@ex.com",
             nickname="normal-run",
             birth_date=date(1994, 1, 1),
             password="pw",
         )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.url = "/api/v1/admin/recommendation-jobs/run/"
+        self.admin_user.refresh_from_db()
+        self.normal_user.refresh_from_db()
 
     def test_admin_recommendation_job_run_unauthorized(self) -> None:
         response = self.client.post(self.url, data={"job_type": "user_refresh"}, format="json")

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -5,6 +5,9 @@ from config.settings.base import *
 
 DEBUG = True
 
+# 테스트 속도 최적화: 빠른 해시 알고리즘 사용 (보안 불필요한 테스트 환경)
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
 RAW_ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "")
 if not RAW_ALLOWED_HOSTS:
     raise ValueError("DJANGO_ALLOWED_HOSTS must be set")

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -1,6 +1,9 @@
 from config.settings.base import *
 
 DEBUG = True
+
+# 테스트 속도 최적화: 빠른 해시 알고리즘 사용 (보안 불필요한 테스트 환경)
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 ALLOWED_HOSTS = ["*"]
 
 if DEBUG:

--- a/resources/scripts/test.sh
+++ b/resources/scripts/test.sh
@@ -12,7 +12,7 @@ poetry run dmypy run -- .
 echo "OK"
 
 echo "${COLOR_BLUE}Starting Django Test with coverage${COLOR_NC}"
-poetry run coverage run manage.py test
+poetry run coverage run manage.py test --keepdb
 poetry run coverage report -m
 poetry run coverage html
 


### PR DESCRIPTION
### Test Code 병목 이유

```
 # 이 한 줄이 내부적으로 600,000번 연산
User.objects.create_user(email="test@example.com", password="pw")
```

 실제 로그인 테스트라면 검증까지 포함해서 이 연산이 2번 (저장 + 검증) 일어납니다.

  테스트에서 비밀번호는 실제로 보호할 필요가 없으니 "pw" 라는 문자열이 저장되고 검증되는 흐름만 테스트하면 되기 때문에, 알고리즘이 얼마나 안전한지는 무관하다고 판단해 dev, local 환경에서 MD5 사용했습니다. 

```
PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
```
MD5는 크래킹에 취약하지만 해싱 자체는 즉각 처리되기 때문에 테스트 전용으로는 괜찮을 것 같았습니다. 