### PR TITLE
[Refactor: similarity_rebuild] 작업 연결 및 GameSimilarity 적재 구현

### DIFF
--- a/apps/recommendations/tasks.py
+++ b/apps/recommendations/tasks.py
@@ -80,6 +80,9 @@ def _build_similarity_pairs_from_interactions() -> dict[tuple[int, int], Decimal
     ).iterator()
     user_games: defaultdict[int, set[int]] = defaultdict(set)
     for user_id, game_id in user_rows_iterator:
+        # mypy 관점에서는 values_list가 Optional을 반환할 수 있어 타입 가드를 추가합니다.
+        if game_id is None:
+            continue
         user_games[user_id].add(int(game_id))
 
     game_user_count: defaultdict[int, int] = defaultdict(int)

--- a/apps/recommendations/tasks.py
+++ b/apps/recommendations/tasks.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import timedelta
 from decimal import Decimal
 from math import sqrt
-from typing import DefaultDict
-from collections import defaultdict
 
 from celery import shared_task
 from django.db import transaction
@@ -75,15 +74,16 @@ def _upsert_recommendations(
 
 
 def _build_similarity_pairs_from_interactions() -> dict[tuple[int, int], Decimal]:
-    user_rows = InteractionLog.objects.filter(igdb_game_id__isnull=False).values_list("user_id", "igdb_game_id")
-    user_games: DefaultDict[int, set[int]] = defaultdict(set)
-    for user_id, game_id in user_rows:
-        if game_id is None:
-            continue
+    # 대량 InteractionLog를 한 번에 메모리에 올리지 않기 위해 iterator로 스트리밍 처리합니다.
+    user_rows_iterator = (
+        InteractionLog.objects.filter(igdb_game_id__isnull=False).values_list("user_id", "igdb_game_id")
+    ).iterator()
+    user_games: defaultdict[int, set[int]] = defaultdict(set)
+    for user_id, game_id in user_rows_iterator:
         user_games[user_id].add(int(game_id))
 
-    game_user_count: DefaultDict[int, int] = defaultdict(int)
-    co_occurrence: DefaultDict[tuple[int, int], int] = defaultdict(int)
+    game_user_count: defaultdict[int, int] = defaultdict(int)
+    co_occurrence: defaultdict[tuple[int, int], int] = defaultdict(int)
 
     for games in user_games.values():
         game_ids = sorted(games)
@@ -108,7 +108,7 @@ def _build_similarity_pairs_from_interactions() -> dict[tuple[int, int], Decimal
 
 
 def _replace_game_similarities(*, pair_scores: dict[tuple[int, int], Decimal]) -> int:
-    top_per_game: DefaultDict[int, list[tuple[int, Decimal]]] = defaultdict(list)
+    top_per_game: defaultdict[int, list[tuple[int, Decimal]]] = defaultdict(list)
     for (game_id, similar_game_id), score in pair_scores.items():
         top_per_game[game_id].append((similar_game_id, score))
 

--- a/apps/recommendations/tasks.py
+++ b/apps/recommendations/tasks.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 from decimal import Decimal
+from math import sqrt
+from typing import DefaultDict
+from collections import defaultdict
 
 from celery import shared_task
 from django.db import transaction
@@ -16,6 +19,7 @@ MAX_SEED_GAMES = 20
 MAX_RECENT_LOG_SCAN = 200
 MAX_RECOMMENDATIONS = 50
 RECOMMENDATION_EXPIRE_DAYS = 7
+MAX_SIMILAR_PER_GAME = 50
 
 
 def _collect_seed_game_ids(*, user_id: int) -> list[int]:
@@ -68,6 +72,64 @@ def _upsert_recommendations(
         )
 
     UserRecommendation.objects.filter(user_id=user_id).exclude(generation_version=generation_version).delete()
+
+
+def _build_similarity_pairs_from_interactions() -> dict[tuple[int, int], Decimal]:
+    user_rows = InteractionLog.objects.filter(igdb_game_id__isnull=False).values_list("user_id", "igdb_game_id")
+    user_games: DefaultDict[int, set[int]] = defaultdict(set)
+    for user_id, game_id in user_rows:
+        if game_id is None:
+            continue
+        user_games[user_id].add(int(game_id))
+
+    game_user_count: DefaultDict[int, int] = defaultdict(int)
+    co_occurrence: DefaultDict[tuple[int, int], int] = defaultdict(int)
+
+    for games in user_games.values():
+        game_ids = sorted(games)
+        for game_id in game_ids:
+            game_user_count[game_id] += 1
+        for idx, game_id in enumerate(game_ids):
+            for similar_game_id in game_ids[idx + 1 :]:
+                co_occurrence[(game_id, similar_game_id)] += 1
+
+    pair_scores: dict[tuple[int, int], Decimal] = {}
+    for (a, b), overlap in co_occurrence.items():
+        denominator = sqrt(game_user_count[a] * game_user_count[b])
+        if denominator == 0:
+            continue
+        score = Decimal(str(overlap / denominator)).quantize(Decimal("0.0001"))
+        if score <= 0:
+            continue
+        pair_scores[(a, b)] = score
+        pair_scores[(b, a)] = score
+
+    return pair_scores
+
+
+def _replace_game_similarities(*, pair_scores: dict[tuple[int, int], Decimal]) -> int:
+    top_per_game: DefaultDict[int, list[tuple[int, Decimal]]] = defaultdict(list)
+    for (game_id, similar_game_id), score in pair_scores.items():
+        top_per_game[game_id].append((similar_game_id, score))
+
+    records: list[GameSimilarity] = []
+    for game_id, similars in top_per_game.items():
+        ranked_similars = sorted(similars, key=lambda item: item[1], reverse=True)[:MAX_SIMILAR_PER_GAME]
+        for similar_game_id, score in ranked_similars:
+            records.append(
+                GameSimilarity(
+                    igdb_game_id=game_id,
+                    igdb_similar_game_id=similar_game_id,
+                    score=score,
+                )
+            )
+
+    with transaction.atomic():
+        GameSimilarity.objects.all().delete()
+        if records:
+            GameSimilarity.objects.bulk_create(records, batch_size=1000)
+
+    return len(records)
 
 
 @shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=3)
@@ -137,10 +199,58 @@ def run_user_refresh_job(job_id: int) -> None:
         raise
 
 
+@shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=3)
+def process_similarity_rebuild_job(self, job_id: int) -> None:  # type: ignore[no-untyped-def]
+    run_similarity_rebuild_job(job_id)
+
+
+def run_similarity_rebuild_job(job_id: int) -> None:
+    current_retry_count = 0
+    with transaction.atomic():
+        job = (
+            RecommendationJob.objects.select_for_update()
+            .filter(
+                id=job_id,
+                job_type=RecommendationJob.JobType.SIMILARITY_REBUILD,
+            )
+            .first()
+        )
+        if job is None:
+            return
+        if job.status == RecommendationJob.Status.PENDING:
+            pass
+        elif job.status == RecommendationJob.Status.RUNNING and job.started_at is None:
+            pass
+        else:
+            return
+        current_retry_count = job.retry_count
+
+        job.status = RecommendationJob.Status.RUNNING
+        job.started_at = timezone.now()
+        job.error_message = None
+        job.save(update_fields=["status", "started_at", "error_message"])
+
+    try:
+        pair_scores = _build_similarity_pairs_from_interactions()
+        _replace_game_similarities(pair_scores=pair_scores)
+        RecommendationJob.objects.filter(id=job_id).update(
+            status=RecommendationJob.Status.SUCCESS,
+            finished_at=timezone.now(),
+        )
+    except Exception as err:
+        RecommendationJob.objects.filter(id=job_id).update(
+            status=RecommendationJob.Status.FAILED,
+            finished_at=timezone.now(),
+            retry_count=current_retry_count + 1,
+            error_message=str(err)[:1000],
+        )
+        raise
+
+
 @shared_task
 def process_pending_recommendation_jobs(limit: int = 20) -> int:
     with transaction.atomic():
-        pending_job_ids = list(
+        pending_user_refresh_job_ids = list(
             RecommendationJob.objects.select_for_update(skip_locked=True)
             .filter(
                 job_type=RecommendationJob.JobType.USER_REFRESH,
@@ -151,15 +261,40 @@ def process_pending_recommendation_jobs(limit: int = 20) -> int:
             .values_list("id", flat=True)[:limit]
         )
 
-        if pending_job_ids:
+        if pending_user_refresh_job_ids:
             RecommendationJob.objects.filter(
-                id__in=pending_job_ids,
+                id__in=pending_user_refresh_job_ids,
                 status=RecommendationJob.Status.PENDING,
             ).update(
                 status=RecommendationJob.Status.RUNNING,
                 started_at=None,
             )
 
-    for job_id in pending_job_ids:
+    remaining_limit = max(limit - len(pending_user_refresh_job_ids), 0)
+    pending_similarity_rebuild_job_ids: list[int] = []
+    if remaining_limit > 0:
+        with transaction.atomic():
+            pending_similarity_rebuild_job_ids = list(
+                RecommendationJob.objects.select_for_update(skip_locked=True)
+                .filter(
+                    job_type=RecommendationJob.JobType.SIMILARITY_REBUILD,
+                    status=RecommendationJob.Status.PENDING,
+                )
+                .order_by("created_at")
+                .values_list("id", flat=True)[:remaining_limit]
+            )
+            if pending_similarity_rebuild_job_ids:
+                RecommendationJob.objects.filter(
+                    id__in=pending_similarity_rebuild_job_ids,
+                    status=RecommendationJob.Status.PENDING,
+                ).update(
+                    status=RecommendationJob.Status.RUNNING,
+                    started_at=None,
+                )
+
+    for job_id in pending_user_refresh_job_ids:
         process_user_refresh_job.delay(job_id)
-    return len(pending_job_ids)
+    for job_id in pending_similarity_rebuild_job_ids:
+        process_similarity_rebuild_job.delay(job_id)
+
+    return len(pending_user_refresh_job_ids) + len(pending_similarity_rebuild_job_ids)

--- a/apps/recommendations/tests.py
+++ b/apps/recommendations/tests.py
@@ -439,9 +439,7 @@ class RecommendationTaskTestCase(TestCase):
 
         job.refresh_from_db()
         self.assertEqual(job.status, RecommendationJob.Status.SUCCESS)
-        self.assertTrue(
-            GameSimilarity.objects.filter(igdb_game_id=9001, igdb_similar_game_id=9002).exists()
-        )
+        self.assertTrue(GameSimilarity.objects.filter(igdb_game_id=9001, igdb_similar_game_id=9002).exists())
 
     def test_run_user_refresh_job_skips_when_job_already_running(self) -> None:
         user = self._create_user()

--- a/apps/recommendations/tests.py
+++ b/apps/recommendations/tests.py
@@ -17,6 +17,7 @@ from apps.recommendations.tasks import (
     _collect_seed_game_ids,
     _upsert_recommendations,
     process_pending_recommendation_jobs,
+    run_similarity_rebuild_job,
     run_user_refresh_job,
 )
 from apps.users.models import User
@@ -395,6 +396,53 @@ class RecommendationTaskTestCase(TestCase):
         self.assertEqual(job.retry_count, 1)
         self.assertIn("boom", cast(str, job.error_message))
 
+    def test_run_similarity_rebuild_job_success(self) -> None:
+        user_a = self._create_user()
+        user_b = User.objects.create_user(
+            email="rec-user2@ex.com",
+            nickname="rec-user2",
+            birth_date=date(1994, 1, 1),
+            password="pw",
+        )
+
+        InteractionLog.objects.create(
+            user=user_a,
+            igdb_game_id=9001,
+            type=InteractionLog.ActionType.VIEW,
+            source=InteractionLog.SourceType.DETAIL_PAGE,
+        )
+        InteractionLog.objects.create(
+            user=user_a,
+            igdb_game_id=9002,
+            type=InteractionLog.ActionType.VIEW,
+            source=InteractionLog.SourceType.DETAIL_PAGE,
+        )
+        InteractionLog.objects.create(
+            user=user_b,
+            igdb_game_id=9001,
+            type=InteractionLog.ActionType.VIEW,
+            source=InteractionLog.SourceType.DETAIL_PAGE,
+        )
+        InteractionLog.objects.create(
+            user=user_b,
+            igdb_game_id=9002,
+            type=InteractionLog.ActionType.VIEW,
+            source=InteractionLog.SourceType.DETAIL_PAGE,
+        )
+
+        job = RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.SIMILARITY_REBUILD,
+            target_user=None,
+            status=RecommendationJob.Status.PENDING,
+        )
+        run_similarity_rebuild_job(job.id)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, RecommendationJob.Status.SUCCESS)
+        self.assertTrue(
+            GameSimilarity.objects.filter(igdb_game_id=9001, igdb_similar_game_id=9002).exists()
+        )
+
     def test_run_user_refresh_job_skips_when_job_already_running(self) -> None:
         user = self._create_user()
         job = RecommendationJob.objects.create(
@@ -409,6 +457,21 @@ class RecommendationTaskTestCase(TestCase):
         job.refresh_from_db()
         self.assertEqual(job.status, RecommendationJob.Status.RUNNING)
         self.assertFalse(UserRecommendation.objects.filter(user=user).exists())
+
+    def test_process_pending_recommendation_jobs_enqueues_similarity_rebuild(self) -> None:
+        similarity_job = RecommendationJob.objects.create(
+            job_type=RecommendationJob.JobType.SIMILARITY_REBUILD,
+            target_user=None,
+            status=RecommendationJob.Status.PENDING,
+        )
+
+        with patch("apps.recommendations.tasks.process_similarity_rebuild_job.delay") as mocked_delay:
+            queued = process_pending_recommendation_jobs(limit=20)
+
+        self.assertEqual(queued, 1)
+        mocked_delay.assert_called_once_with(similarity_job.id)
+        similarity_job.refresh_from_db()
+        self.assertEqual(similarity_job.status, RecommendationJob.Status.RUNNING)
 
     def test_process_pending_recommendation_jobs_enqueues_pending_only(self) -> None:
         user = self._create_user()
@@ -750,3 +813,18 @@ class AdminRecommendationJobRunAPITestCase(TestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+
+    def test_admin_recommendation_job_run_similarity_rebuild_enqueues(self) -> None:
+        self.client.force_authenticate(user=self.admin_user)
+
+        with patch("apps.recommendations.views_admin.process_similarity_rebuild_job.delay") as mocked_delay:
+            response = self.client.post(
+                self.url,
+                data={"job_type": "similarity_rebuild"},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 201)
+        payload = cast(dict[str, Any], response.data)
+        self.assertEqual(payload["type"], RecommendationJob.JobType.SIMILARITY_REBUILD)
+        mocked_delay.assert_called_once_with(payload["id"])

--- a/apps/recommendations/views_admin.py
+++ b/apps/recommendations/views_admin.py
@@ -28,7 +28,7 @@ from apps.recommendations.serializers import (
     RecommendationJobRunResponseSerializer,
 )
 from apps.recommendations.services import RecommendationAdminService
-from apps.recommendations.tasks import process_user_refresh_job
+from apps.recommendations.tasks import process_similarity_rebuild_job, process_user_refresh_job
 from apps.users.models import User
 
 
@@ -329,6 +329,8 @@ class AdminRecommendationJobRunView(APIView):
         )
         if job.job_type == RecommendationJob.JobType.USER_REFRESH and job.target_user_id is not None:
             process_user_refresh_job.delay(job.id)
+        elif job.job_type == RecommendationJob.JobType.SIMILARITY_REBUILD:
+            process_similarity_rebuild_job.delay(job.id)
 
         serializer = RecommendationJobRunResponseSerializer(job)
         return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## ✅ PR 요약
- similarity_rebuild 추천 작업이 실제로 실행되도록 Celery 태스크 연결을 추가

## 📄 상세 내용
- [x] POST /api/v1/admin/recommendation-jobs/run/에서 job_type=similarity_rebuild 요청 시process_similarity_rebuild_job.delay()를 호출하도록 수정
- [x] un_similarity_rebuild_job() / process_similarity_rebuild_job() 추가
- [x] 상호작용 로그로 게임 공기반(co-occurrence) 유사도 점수 계산 후 GameSimilarity 일괄 재적재
- [x] process_pending_recommendation_jobs()가 SIMILARITY_REBUILD pending job도 가져와 실행하도록 변경

## 🧪 테스트
- [x] 로컬에서 확인했습니다.
- [x] 빌드/린트가 통과합니다. (가능한 경우)

## 📌 체크리스트
- [x] 불필요한 로그/디버그 코드를 제거했습니다.
- [ ] 관련 이슈/작업 링크를 남겼습니다. (선택)
