### PR TITLE
[fix(recommendations)]

### DIFF
--- a/apps/recommendations/tasks.py
+++ b/apps/recommendations/tasks.py
@@ -207,6 +207,23 @@ def process_similarity_rebuild_job(self, job_id: int) -> None:  # type: ignore[n
     run_similarity_rebuild_job(job_id)
 
 
+@shared_task
+def enqueue_similarity_rebuild_job_if_needed() -> int:
+    has_running_or_pending = RecommendationJob.objects.filter(
+        job_type=RecommendationJob.JobType.SIMILARITY_REBUILD,
+        status__in=[RecommendationJob.Status.PENDING, RecommendationJob.Status.RUNNING],
+    ).exists()
+    if has_running_or_pending:
+        return 0
+
+    RecommendationJob.objects.create(
+        job_type=RecommendationJob.JobType.SIMILARITY_REBUILD,
+        target_user=None,
+        status=RecommendationJob.Status.PENDING,
+    )
+    return 1
+
+
 def run_similarity_rebuild_job(job_id: int) -> None:
     current_retry_count = 0
     with transaction.atomic():

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -257,6 +257,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "apps.users.tasks.purge_soft_deleted_users",
         "schedule": crontab(hour=4, minute=0),
     },
+    "recommendation-enqueue-similarity-rebuild-twice-daily": {
+        "task": "apps.recommendations.tasks.enqueue_similarity_rebuild_job_if_needed",
+        "schedule": crontab(hour="0,12", minute=0),
+    },
     "recommendation-process-pending-jobs": {
         "task": "apps.recommendations.tasks.process_pending_recommendation_jobs",
         "schedule": timedelta(seconds=30),


### PR DESCRIPTION
보류 중이거나 실행 중인 재구축 작업이 없을 때만 similarity_rebuild를 큐에 추가하는 Celery 작업을 생성하고, 중복 작업 없이 유사성 데이터가 자동으로 새로 고쳐지도록 00:00 및 12:00에 해당 작업을 트리거합니다
