### PR TITLE
fix: 유사 게임 이미지, 평점 오류 수정

### DIFF
--- a/apps/games/igdb/response_builder.py
+++ b/apps/games/igdb/response_builder.py
@@ -130,7 +130,7 @@ def build_similar_game_item(raw: dict[str, Any], similarity_score: float) -> dic
         "id": raw["id"],
         "name": raw.get("name", ""),
         "slug": raw.get("slug", ""),
-        "thumbnail_img_url": _parse_cover_url(raw.get("cover")),
-        "rawg_rating": _parse_rating(raw.get("rating")),
+        "thumbnail_img_url": raw.get("thumbnail_img_url", ""),
+        "rawg_rating": raw.get("rawg_rating") or 0,
         "similarity_score": similarity_score,
     }

--- a/apps/games/tests/test_igdb_response_builder.py
+++ b/apps/games/tests/test_igdb_response_builder.py
@@ -182,19 +182,20 @@ class BuildGameDetailTests(SimpleTestCase):
 
 
 class BuildSimilarGameItemTests(SimpleTestCase):
-    def _make_raw(self, **overrides: Any) -> dict[str, Any]:
+    def _make_detail(self, **overrides: Any) -> dict[str, Any]:
+        # build_game_detail() 출력 포맷 (get_games_by_ids가 반환하는 형태)
         base: dict[str, Any] = {
             "id": 100,
             "name": "Similar Game",
             "slug": "similar-game",
-            "cover": {"image_id": "co999"},
-            "rating": 60.0,
+            "thumbnail_img_url": "//images.igdb.com/igdb/image/upload/t_cover_big/co999.jpg",
+            "rawg_rating": Decimal("6.00"),
         }
         base.update(overrides)
         return base
 
     def test_basic(self) -> None:
-        result = build_similar_game_item(self._make_raw(), 0.85)
+        result = build_similar_game_item(self._make_detail(), 0.85)
         self.assertEqual(result["id"], 100)
         self.assertEqual(result["name"], "Similar Game")
         self.assertEqual(result["slug"], "similar-game")
@@ -202,9 +203,9 @@ class BuildSimilarGameItemTests(SimpleTestCase):
         self.assertEqual(result["similarity_score"], 0.85)
 
     def test_no_cover(self) -> None:
-        result = build_similar_game_item(self._make_raw(cover=None), 0.5)
+        result = build_similar_game_item(self._make_detail(thumbnail_img_url=""), 0.5)
         self.assertEqual(result["thumbnail_img_url"], "")
 
     def test_no_rating(self) -> None:
-        result = build_similar_game_item(self._make_raw(rating=None), 0.5)
-        self.assertEqual(result["rawg_rating"], Decimal("0.00"))
+        result = build_similar_game_item(self._make_detail(rawg_rating=0), 0.5)
+        self.assertEqual(result["rawg_rating"], 0)


### PR DESCRIPTION
get_games_by_ids()는 이미 build_game_detail()로 가공된 dict를 반환하는데, build_similar_game_item()에서 원본 IGDB 데이터인 것처럼 raw.get("cover")를 다시 파싱하려고 해서 항상 빈 문자열이 나왔음. 그냥 build_similar_game_item()에서 thumbnail_img_url을 그냥 그대로 가져오면 됩니다.

그니까 함수간 계약 불일치 수정했다는 말입니다.