### PR TITLE
[Feature] users/me 및 auth/me 응답에 is_staff 추가

### DIFF
--- a/apps/users/serializers/auth.py
+++ b/apps/users/serializers/auth.py
@@ -70,5 +70,6 @@ class AuthMeResponseSerializer(serializers.ModelSerializer[User]):
             "id",
             "email",
             "is_active",
+            "is_staff",
             "is_adult_verified",
         ]

--- a/apps/users/serializers/me.py
+++ b/apps/users/serializers/me.py
@@ -18,6 +18,7 @@ class UserMeResponseSerializer(serializers.ModelSerializer[User]):
             "is_adult_verified",
             "adult_verified_at",
             "is_active",
+            "is_staff",
             "is_social_user",
             "social_provider",
             "created_at",

--- a/apps/users/tests/test_auth_me.py
+++ b/apps/users/tests/test_auth_me.py
@@ -50,6 +50,7 @@ class AuthMeAPITestCase(FastTestCase):
                 "id": self.user.id,
                 "email": self.user.email,
                 "is_active": self.user.is_active,
+                "is_staff": self.user.is_staff,
                 "is_adult_verified": self.user.is_adult_verified,
             },
         )

--- a/apps/users/tests/test_user_me.py
+++ b/apps/users/tests/test_user_me.py
@@ -41,6 +41,7 @@ class UserMeRetrieveAPITest(FastTestCase):
         self.assertEqual(drf_res.data["is_adult_verified"], self.user.is_adult_verified)
         self.assertEqual(drf_res.data["adult_verified_at"], self.user.adult_verified_at)
         self.assertEqual(drf_res.data["is_active"], self.user.is_active)
+        self.assertEqual(drf_res.data["is_staff"], self.user.is_staff)
         self.assertFalse(drf_res.data["is_social_user"])
         self.assertIsNone(drf_res.data["social_provider"])
         self.assertTrue(drf_res.data["created_at"])


### PR DESCRIPTION
## 작업 내용
- 프론트에서 관리자 여부를 바로 분기할 수 있도록 `users/me`, `auth/me` 응답에 `is_staff` 필드를 추가했습니다.

## 상세 변경 사항
- `GET /api/v1/users/me/` 응답에 `is_staff` 필드를 추가했습니다.
- `GET /api/v1/auth/me/` 응답에 `is_staff` 필드를 추가했습니다.
- 프론트에서 별도 추가 조회 없이 관리자 UI/권한 분기를 할 수 있도록 응답 정보를 보강했습니다.
- 관련 테스트 기대값을 함께 업데이트했습니다.
