### PR TITLE
fix: fill_name_ko pickle 직렬화 지원 및 Redis 캐시 패턴 수정

### DIFF
--- a/apps/games/management/commands/fill_name_ko.py
+++ b/apps/games/management/commands/fill_name_ko.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
 
     def _collect_all_from_igdb_cache(self, r: Any) -> dict[int, str]:
         """IGDB 게임 캐시(*igdb:game:*, *igdb:search:*)에서 id→slug 수집"""
-        import json
+        import pickle
 
         igdb_id_to_slug: dict[int, str] = {}
 
@@ -103,12 +103,12 @@ class Command(BaseCommand):
                 data = r.get(key)
                 if data:
                     try:
-                        game = json.loads(data)
+                        game = pickle.loads(data)
                         igdb_id = game.get("id")
                         slug = game.get("slug")
                         if igdb_id and slug:
                             igdb_id_to_slug[int(igdb_id)] = slug
-                    except (ValueError, KeyError, TypeError):
+                    except (ValueError, KeyError, TypeError, pickle.UnpicklingError):
                         pass
             if cursor == 0:
                 break
@@ -121,14 +121,14 @@ class Command(BaseCommand):
                 data = r.get(key)
                 if data:
                     try:
-                        games = json.loads(data)
+                        games = pickle.loads(data)
                         if isinstance(games, list):
                             for game in games:
                                 igdb_id = game.get("id")
                                 slug = game.get("slug")
                                 if igdb_id and slug:
                                     igdb_id_to_slug[int(igdb_id)] = slug
-                    except (ValueError, KeyError, TypeError):
+                    except (ValueError, KeyError, TypeError, pickle.UnpicklingError):
                         pass
             if cursor == 0:
                 break

--- a/apps/games/tests/test_fill_name_ko.py
+++ b/apps/games/tests/test_fill_name_ko.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from io import StringIO
 from unittest.mock import MagicMock, patch
@@ -16,7 +15,7 @@ class FillNameKoCommandTest(TestCase):
         logging.disable(logging.CRITICAL)
 
     def tearDown(self) -> None:
-        cache.clear()
+        self.r.flushdb()
         logging.disable(logging.NOTSET)
 
     def _call(self, *args: str) -> str:
@@ -67,7 +66,8 @@ class FillNameKoCommandTest(TestCase):
     def test_overwrite_uses_igdb_cache(self, mock_bulk: MagicMock) -> None:
         mock_bulk.return_value = {1942: "더 위처 3"}
 
-        self.r.set("igdb:game:1942", json.dumps({"id": 1942, "slug": "the-witcher-3-wild-hunt"}))
+        # django-redis를 통해 캐시 설정 (자동으로 prefix 추가됨)
+        cache.set("igdb:game:1942", {"id": 1942, "slug": "the-witcher-3-wild-hunt"})
 
         output = self._call("--overwrite")
         mock_bulk.assert_called_once()


### PR DESCRIPTION
- django-redis가 pickle로 직렬화하므로 pickle.loads() 사용

제발 좀;;