### PR TITLE
feat: 부모 게임 추론 및 에디션 suffix 처리 추가

### DIFF
--- a/apps/games/igdb/client.py
+++ b/apps/games/igdb/client.py
@@ -246,6 +246,7 @@ class IgdbClient:
         fields = (
             "id,name,slug,summary,storyline,"
             "alternative_names.name,alternative_names.comment,"
+            "parent_game,"
             "first_release_date,status,"
             "cover.image_id,"
             "rating,rating_count,aggregated_rating,"
@@ -282,6 +283,7 @@ class IgdbClient:
         fields = (
             "id,name,slug,summary,"
             "alternative_names.name,alternative_names.comment,"
+            "parent_game,"
             "first_release_date,"
             "rating,rating_count,"
             "cover.image_id,"
@@ -350,6 +352,7 @@ class IgdbClient:
         fields = (
             "id,name,slug,summary,"
             "alternative_names.name,alternative_names.comment,"
+            "parent_game,"
             "first_release_date,"
             "rating,rating_count,"
             "cover.image_id,"

--- a/apps/games/igdb/converters.py
+++ b/apps/games/igdb/converters.py
@@ -249,11 +249,15 @@ def extract_korean_from_alt_names(raw: dict[str, Any]) -> str | None:
     """
     IGDB alternative_names 배열에서 한국어 이름 추출
     comment 필드에 'korean' 또는 '한국' 포함 시 반환
+    abbreviation(약어)은 제외
     """
     for alt in raw.get("alternative_names") or []:
         if not isinstance(alt, dict):
             continue
         comment = (alt.get("comment") or "").lower()
+        # 약어는 제외
+        if "abbreviation" in comment:
+            continue
         if "korean" in comment or "한국" in comment:
             name = alt.get("name", "").strip()
             if name:

--- a/apps/games/tests/test_wikidata_resolvers.py
+++ b/apps/games/tests/test_wikidata_resolvers.py
@@ -57,3 +57,89 @@ class ResolveNameKoTest(TestCase):
             mock_task.delay = MagicMock()
             _maybe_enqueue(1942, "the-witcher-3-wild-hunt")
             mock_task.delay.assert_called_once_with(1942, "the-witcher-3-wild-hunt")
+
+    @patch("apps.games.wikidata.resolvers.acquire_enqueue_lock", return_value=False)
+    def test_parent_game_with_edition_suffix(self, _mock: MagicMock) -> None:
+        """parent_game의 한국어 이름 + 에디션 suffix 조합"""
+        from apps.games.wikidata.client import save_name_ko
+        from apps.games.wikidata.resolvers import resolve_name_ko
+
+        # 부모 게임 한국어 이름 저장
+        save_name_ko(119133, "젤다의 전설: 티어스 오브 더 킹덤")
+
+        # 자식 게임 (Switch 2 Edition)
+        raw = {
+            "name": "The Legend of Zelda: Tears of the Kingdom - Nintendo Switch 2 Edition",
+            "parent_game": 119133,
+            "slug": "the-legend-of-zelda-tears-of-the-kingdom-nintendo-switch-2-edition",
+        }
+        result = resolve_name_ko(338073, raw)
+        self.assertEqual(result, "젤다의 전설: 티어스 오브 더 킹덤 - Nintendo Switch 2 Edition")
+
+    @patch("apps.games.wikidata.resolvers.acquire_enqueue_lock", return_value=False)
+    def test_parent_game_without_suffix(self, _mock: MagicMock) -> None:
+        """에디션 suffix 없으면 부모 게임 이름만 사용"""
+        from apps.games.wikidata.client import save_name_ko
+        from apps.games.wikidata.resolvers import resolve_name_ko
+
+        save_name_ko(1942, "더 위처 3")
+
+        raw = {
+            "name": "The Witcher 3",
+            "parent_game": 1942,
+            "slug": "the-witcher-3",
+        }
+        result = resolve_name_ko(9999, raw)
+        self.assertEqual(result, "더 위처 3")
+
+    @patch("apps.games.wikidata.resolvers.acquire_enqueue_lock", return_value=False)
+    def test_parent_game_no_korean_name(self, _mock: MagicMock) -> None:
+        """부모 게임에 한국어 이름 없으면 alternative_names fallback"""
+        from apps.games.wikidata.resolvers import resolve_name_ko
+
+        raw = {
+            "name": "Some Game - Deluxe Edition",
+            "parent_game": 9999,
+            "slug": "some-game-deluxe",
+            "alternative_names": [{"name": "어떤 게임", "comment": "Korean"}],
+        }
+        result = resolve_name_ko(8888, raw)
+        self.assertEqual(result, "어떤 게임")
+
+
+class ExtractEditionSuffixTest(TestCase):
+    def test_extracts_edition_with_dash(self) -> None:
+        from apps.games.wikidata.resolvers import _extract_edition_suffix
+
+        result = _extract_edition_suffix("The Legend of Zelda: Tears of the Kingdom - Nintendo Switch 2 Edition")
+        self.assertEqual(result, "Nintendo Switch 2 Edition")
+
+    def test_extracts_edition_with_colon(self) -> None:
+        from apps.games.wikidata.resolvers import _extract_edition_suffix
+
+        result = _extract_edition_suffix("Assassin's Creed II: Deluxe Edition")
+        self.assertEqual(result, "Deluxe Edition")
+
+    def test_extracts_collection(self) -> None:
+        from apps.games.wikidata.resolvers import _extract_edition_suffix
+
+        result = _extract_edition_suffix("Metal Gear Solid - The Legacy Collection")
+        self.assertEqual(result, "The Legacy Collection")
+
+    def test_no_edition_returns_empty(self) -> None:
+        from apps.games.wikidata.resolvers import _extract_edition_suffix
+
+        result = _extract_edition_suffix("The Witcher 3: Wild Hunt")
+        self.assertEqual(result, "")
+
+    def test_extracts_randomizer(self) -> None:
+        from apps.games.wikidata.resolvers import _extract_edition_suffix
+
+        result = _extract_edition_suffix("The Legend of Zelda: Tears of the Kingdom Randomizer")
+        self.assertEqual(result, "Randomizer")
+
+    def test_extracts_mod(self) -> None:
+        from apps.games.wikidata.resolvers import _extract_edition_suffix
+
+        result = _extract_edition_suffix("The Legend of Zelda: Tears of the Kingdom - Better Sages Mod")
+        self.assertEqual(result, "Better Sages Mod")

--- a/apps/games/wikidata/client.py
+++ b/apps/games/wikidata/client.py
@@ -199,6 +199,8 @@ def fetch_and_save_bulk(igdb_id_to_slug: dict[int, str]) -> dict[int, str | None
     """
     SPARQL 조회 후 Redis에 저장. Celery worker에서만 호출
     반환: {igdb_id: name_ko or None}
+
+    개선: 실패 시 에디션 suffix 제거 후 재시도
     """
     result: dict[int, str | None] = {}
     items = list(igdb_id_to_slug.items())
@@ -207,6 +209,19 @@ def fetch_and_save_bulk(igdb_id_to_slug: dict[int, str]) -> dict[int, str | None
         chunk = items[i : i + _BULK_CHUNK_SIZE]
         slug_to_id = {slug: igdb_id for igdb_id, slug in chunk}
         fetched = sparql_query(slug_to_id)
+
+        # 실패한 것들 에디션 suffix 제거 후 재시도
+        failed_slugs = {}
+        for igdb_id, slug in chunk:
+            if igdb_id not in fetched:
+                cleaned_slug = _remove_edition_suffix(slug)
+                if cleaned_slug != slug:
+                    failed_slugs[cleaned_slug] = igdb_id
+
+        # 재시도
+        if failed_slugs:
+            retry_fetched = sparql_query(failed_slugs)
+            fetched.update(retry_fetched)
 
         for igdb_id, slug in chunk:
             name_ko = fetched.get(igdb_id)
@@ -217,3 +232,42 @@ def fetch_and_save_bulk(igdb_id_to_slug: dict[int, str]) -> dict[int, str | None
             time.sleep(_REQUEST_INTERVAL)
 
     return result
+
+
+def _remove_edition_suffix(slug: str) -> str:
+    """
+    에디션 suffix 제거
+    예: 'silent-hill-2--1' -> 'silent-hill-2'
+        'assassins-creed-ii-deluxe-edition' -> 'assassins-creed-ii'
+    """
+    import re
+
+    # 숫자 suffix 제거 (--1, --2 등)
+    slug = re.sub(r"--\d+$", "", slug)
+
+    # 에디션 관련 suffix 제거
+    edition_suffixes = [
+        "-deluxe-edition",
+        "-gold-edition",
+        "-goty-edition",
+        "-game-of-the-year-edition",
+        "-complete-edition",
+        "-definitive-edition",
+        "-ultimate-edition",
+        "-special-edition",
+        "-collectors-edition",
+        "-enhanced-edition",
+        "-remastered",
+        "-remake",
+        "-hd",
+        "-collection",
+        "-bundle",
+        "-legacy-collection",
+        "-omega-collection",
+    ]
+
+    for suffix in edition_suffixes:
+        if slug.endswith(suffix):
+            return slug[: -len(suffix)]
+
+    return slug

--- a/apps/games/wikidata/resolvers.py
+++ b/apps/games/wikidata/resolvers.py
@@ -3,8 +3,9 @@ name_ko resolve 로직
 
 우선순위:
     1. 캐시된 name_ko (Redis Hash, fetched_at 있음)
-    2. IGDB alternative_names (즉시 사용 가능)
-    3. "" → 호출부에서 영어 name fallback
+    2. parent_game의 name_ko + 에디션 suffix
+    3. IGDB alternative_names (즉시 사용 가능)
+    4. "" → 호출부에서 영어 name fallback
 
 캐시 미스(pending) 시 Celery enqueue
 API 요청 중 외부 API 절대 호출하지 않음
@@ -12,6 +13,7 @@ API 요청 중 외부 API 절대 호출하지 않음
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from apps.games.igdb.converters import extract_korean_from_alt_names
@@ -26,19 +28,145 @@ _MAX_FAILED = 3
 
 def resolve_name_ko(igdb_id: int, raw: dict[str, Any]) -> str:
     """
-    캐시 히트 시 즉시 반환
-    캐시 미스(pending) 시 Celery enqueue 후 alternative_names fallback
+    캐시 히트 시 즉시 반환 (suffix 있으면 추가)
+    캐시 미스(pending) 시:
+      1. parent_game 있으면 부모 게임 한국어 + 에디션 suffix
+      2. parent_game 없으면 게임 이름에서 추론 시도
+      3. alternative_names fallback
+      4. Celery enqueue
     실패 횟수 초과 시 enqueue 안 함
     """
     name_ko = get_name_ko_from_cache(igdb_id)
     if name_ko:
+        # 캐시에 있어도 에디션 suffix 추가
+        edition_suffix = _extract_edition_suffix(raw.get("name", ""))
+        if edition_suffix:
+            return f"{name_ko} - {edition_suffix}"
         return name_ko
+
+    # parent_game 활용
+    parent_game_id = raw.get("parent_game")
+
+    # parent_game이 없으면 게임 이름에서 추론 시도
+    if not parent_game_id:
+        parent_game_id = _infer_parent_game_id(raw.get("name", ""))
+
+    if parent_game_id:
+        parent_name_ko = get_name_ko_from_cache(parent_game_id)
+        if parent_name_ko:
+            edition_suffix = _extract_edition_suffix(raw.get("name", ""))
+            if edition_suffix:
+                return f"{parent_name_ko} - {edition_suffix}"
+            return parent_name_ko
 
     slug = raw.get("slug", "")
     if slug:
         _maybe_enqueue(igdb_id, slug)
 
     return extract_korean_from_alt_names(raw) or ""
+
+
+def _extract_edition_suffix(full_name: str) -> str:
+    """
+    게임 이름에서 에디션/모드 suffix 추출
+    예: "The Legend of Zelda: Tears of the Kingdom - Nintendo Switch 2 Edition"
+        -> "Nintendo Switch 2 Edition"
+        "The Legend of Zelda: Tears of the Kingdom Randomizer"
+        -> "Randomizer"
+        "Assassin's Creed II: Deluxe Edition"
+        -> "Deluxe Edition"
+    """
+    # 에디션/모드 키워드
+    suffix_keywords = [
+        "Edition",
+        "Collection",
+        "Bundle",
+        "Remastered",
+        "Remake",
+        "HD",
+        "Randomizer",
+        "Mod",
+        "Online",
+        "DLC",
+        "Expansion",
+    ]
+
+    # 패턴 1: " - suffix" (가장 명확, 최우선)
+    match = re.search(r" - (.+)$", full_name)
+    if match:
+        suffix = match.group(1).strip()
+        if any(keyword.lower() in suffix.lower() for keyword in suffix_keywords):
+            return suffix
+
+    # 패턴 2: ": suffix" (콜론으로 구분, 마지막 콜론 이후)
+    # 예: "Assassin's Creed II: Deluxe Edition" -> "Deluxe Edition"
+    if ": " in full_name:
+        parts = full_name.split(": ")
+        last_part = parts[-1].strip()
+        # 마지막 부분이 짧고 키워드를 포함하는 경우만
+        if len(last_part.split()) <= 3 and any(keyword.lower() in last_part.lower() for keyword in suffix_keywords):
+            return last_part
+
+    # 패턴 3: 마지막 단어가 단독 키워드인 경우 (공백으로 구분)
+    # 예: "Game Name Randomizer" -> "Randomizer"
+    # 주의: "Deluxe Edition"처럼 2단어 이상은 제외 (패턴 2에서 처리)
+    words = full_name.split()
+    if len(words) > 1:
+        last_word = words[-1]
+        # 정확히 일치하는 단독 키워드만 (Randomizer, Mod, Online 등)
+        if any(keyword.lower() == last_word.lower() for keyword in suffix_keywords):
+            # 바로 앞 단어가 키워드가 아닌 경우만 (단독 키워드 확인)
+            if len(words) >= 2:
+                second_last = words[-2]
+                if not any(keyword.lower() == second_last.lower() for keyword in suffix_keywords):
+                    return last_word
+
+    return ""
+
+
+def _infer_parent_game_id(game_name: str) -> int | None:
+    """
+    게임 이름에서 suffix를 제거하고 원본 게임 ID를 추론
+    예: "The Legend of Zelda: Tears of the Kingdom - Collector's Edition"
+        -> "The Legend of Zelda: Tears of the Kingdom" 검색
+        -> 119388 반환
+    """
+    suffix = _extract_edition_suffix(game_name)
+    if not suffix:
+        return None
+
+    # suffix 제거하여 원본 게임 이름 추출
+    base_name = game_name
+    if f" - {suffix}" in base_name:
+        base_name = base_name.replace(f" - {suffix}", "").strip()
+    elif f": {suffix}" in base_name:
+        base_name = base_name.replace(f": {suffix}", "").strip()
+    elif base_name.endswith(f" {suffix}"):
+        base_name = base_name[: -len(f" {suffix}")].strip()
+
+    if not base_name or base_name == game_name:
+        return None
+
+    # IGDB에서 원본 게임 검색
+    try:
+        from apps.games.igdb.client import get_igdb_client
+
+        client = get_igdb_client()
+        results = client.search_games(query=base_name, limit=5)
+
+        # 정확히 일치하는 게임 찾기
+        for game in results:
+            if game.get("name", "").lower() == base_name.lower():
+                return int(game["id"])
+
+        # 정확히 일치하는 게임이 없으면 첫 번째 결과 반환
+        if results:
+            return int(results[0]["id"])
+    except Exception:
+        # IGDB 조회 실패 시 None 반환
+        pass
+
+    return None
 
 
 def _maybe_enqueue(igdb_id: int, slug: str) -> None:


### PR DESCRIPTION
* IGDB 클라이언트 메서드(get_game, search_games, get_games_by_ids)에 parent_game 필드 추가
* 게임 이름에서 에디션 suffix를 제거한 뒤 IGDB 검색을 통해 부모 게임을 찾는 _infer_parent_game_id 구현
* 게임 이름에서 에디션/컬렉션/모드/랜덤라이저 suffix를 파싱하는 _extract_edition_suffix 추가

  * 하이픈(-) 구분 지원 (예: "Game - Collector's Edition")
  * 콜론(:) 구분 지원 (예: "Game: Deluxe Edition")
  * 단일 단어 suffix 지원 (예: "Game Randomizer")
* 부모 게임의 한국어 이름 + 에디션 suffix를 조합하도록 resolve_name_ko 개선
* Wikidata 클라이언트에 재시도 로직을 위한 _remove_edition_suffix 추가
* alternative_names에서 한국어 추출 시 약어(abbreviation) 제외
* 부모 게임 해석 및 suffix 추출에 대한 테스트 코드 추가

이 변경으로 게임 에디션 및 변형에 대한 한국어 이름 처리 개선:

1. parent_game 메타데이터가 있으면 이를 우선 활용
2. IGDB 데이터가 없는 경우 이름 기반으로 부모 게임을 추론
3. 에디션 정보는 한국어 이름에 유지