### PR TITLE
refactor: 단일 genre_id 조회 시 TOP 10 필터 적용으로 변경

### DIFF
--- a/apps/games/tests/test_game_list.py
+++ b/apps/games/tests/test_game_list.py
@@ -239,3 +239,43 @@ class GameListViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNotNone(response.data["previous"])
         self.assertIn("page=1", response.data["previous"])
+
+    def test_single_genre_id_uses_top_10_filter(self) -> None:
+        """단일 genre_id + page=1 + page_size=10 → TOP 10 필터 적용"""
+        with patch("apps.games.services.game_list.igdb_cache.search_games_by_igdb_genre_id") as mock_top10:
+            mock_top10.return_value = MOCK_TOP10_GAMES
+
+            self.client.force_authenticate(user=self.user)
+            # genre_ids=1 (RPG)
+            response = self.client.get(self.url, {"genre_ids": "1", "page": "1", "page_size": "10"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 10)
+        # TOP 10 로직이 호출되었는지 확인
+        mock_top10.assert_called_once()
+        self.assertIsNone(response.data["next"])
+        self.assertIsNone(response.data["previous"])
+
+    @patch("apps.games.services.game_list.igdb_cache.search_games")
+    def test_multiple_genre_ids_uses_normal_search(self, mock_search: MagicMock) -> None:
+        """여러 genre_ids → 일반 검색 로직 사용"""
+        mock_search.return_value = [MOCK_GAME_LIST_ITEM] * 3
+
+        self.client.force_authenticate(user=self.user)
+        # 여러 장르
+        response = self.client.get(self.url, {"genre_ids": "1,2", "page": "1", "page_size": "10"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # 일반 검색이 호출되었는지 확인
+        mock_search.assert_called_once()
+
+    @patch("apps.games.services.game_list.igdb_cache.search_games")
+    def test_single_genre_id_with_different_page_size_uses_normal_search(self, mock_search: MagicMock) -> None:
+        """단일 genre_id지만 page_size != 10 → 일반 검색"""
+        mock_search.return_value = [MOCK_GAME_LIST_ITEM] * 21
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url, {"genre_ids": "1", "page": "1", "page_size": "20"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_search.assert_called_once()

--- a/apps/games/views/game_list.py
+++ b/apps/games/views/game_list.py
@@ -131,10 +131,24 @@ class GameListView(APIView):
         page_size = data.get("page_size", 20)
 
         genre_name = data.get("genre_name")
+        genre_ids = data.get("genre_ids")
 
         user: User | None = request.user if request.user.is_authenticated else None
 
+        # TOP 10 로직: genre_name 또는 단일 genre_id + page=1 + page_size=10
+        use_top_10 = False
         if genre_name:
+            use_top_10 = True
+        elif genre_ids and len(genre_ids) == 1 and page == 1 and page_size == 10:
+            # genre_id를 genre_name으로 변환
+            from apps.games.models import Genre
+
+            genre = Genre.objects.filter(id=genre_ids[0]).first()
+            if genre:
+                genre_name = genre.name
+                use_top_10 = True
+
+        if use_top_10 and genre_name:
             items = GameService.top_n_by_genre(
                 genre_name,
                 user=user,


### PR DESCRIPTION
- 프론트엔드에서 오래된 게임이 TOP 10에 노출되던 문제 대응을 위해 서버 측 로직 보정
  - genre_ids가 단일 값이고 page=1, page_size=10인 경우 TOP 10 필터 적용
  - TOP 10 로직 적용을 위해 내부적으로 genre_id를 genre_name으로 변환
  - genre_name과 genre_ids 파라미터 간 필터링 동작 일관성 보장
  - genre_id 필터링 로직에 대한 테스트 케이스 보강
